### PR TITLE
fix(redaction): cover common token shapes and quoted secret values

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -72,11 +72,20 @@
   }
 
   function redact(value) {
+    // Mirror of redactSensitiveText in lib/common.mjs. Kept inline because the
+    // content script cannot import the module; the canonical version (and its
+    // tests) live in lib/common.mjs and re-redacts the same text at prompt-build.
     return String(value || '')
+      .replace(/-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/g, '[REDACTED_PRIVATE_KEY]')
       .replace(/\bBearer\s+[^\s'"`;&]+/gi, 'Bearer [REDACTED_BEARER]')
       .replace(new RegExp('\\bsk-[A-Za-z0-9_\\-]{12,}\\b', 'g'), '[REDACTED_SECRET]')
+      .replace(/\b[sr]k_(?:live|test)_[0-9A-Za-z]{16,}\b/g, '[REDACTED_SECRET]')
+      .replace(/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, '[REDACTED_SECRET]')
+      .replace(/\b(?:gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{40,})\b/g, '[REDACTED_SECRET]')
+      .replace(/\bAIza[0-9A-Za-z_\-]{35}\b/g, '[REDACTED_SECRET]')
+      .replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, '[REDACTED_SECRET]')
       .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, '[REDACTED_JWT]')
-      .replace(/\b(api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|secret|private[_-]?key)\b\s*[:=]\s*([^\s'"`;&]+)/gi, (_match, key) => `${key}=[REDACTED_SECRET]`);
+      .replace(/\b(api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|secret|private[_-]?key)\b["'`]?\s*[:=]\s*["'`]?([^\s'"`;&]+)/gi, (_match, key) => `${key}=[REDACTED_SECRET]`);
   }
 
   function pageMeta() {

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -38,10 +38,19 @@ When the active tab is a YouTube watch page and transcript text is supplied in t
 If the user message begins with a Hermes skill command such as /skill-name or @skill-name, treat that as an explicit skill invocation: use available skill tools or the listed skill name to load and follow that skill before answering.
 This v0.1 extension is read-only: answer using the active tab, selected text, page text, metadata, and tabs list included in the prompt.`;
 
-const SECRET_ASSIGNMENT_RE = /\b(api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|secret|private[_-]?key)\b\s*[:=]\s*([^\s'"`;&]+)/gi;
+// Allow an optional quote after the key and before the value so secrets in
+// quoted JSON/config (e.g. {"api_key": "abc123"}) are redacted, not just bare
+// key=value assignments.
+const SECRET_ASSIGNMENT_RE = /\b(api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|secret|private[_-]?key)\b["'`]?\s*[:=]\s*["'`]?([^\s'"`;&]+)/gi;
 const BEARER_RE = /\bBearer\s+[^\s'"`;&]+/gi;
 const OPENAI_STYLE_RE = new RegExp('\\bsk-[A-Za-z0-9_\\-]{12,}\\b', 'g');
+const STRIPE_KEY_RE = /\b[sr]k_(?:live|test)_[0-9A-Za-z]{16,}\b/g;
+const AWS_ACCESS_KEY_RE = /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g;
+const GITHUB_TOKEN_RE = /\b(?:gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{40,})\b/g;
+const GOOGLE_API_KEY_RE = /\bAIza[0-9A-Za-z_\-]{35}\b/g;
+const SLACK_TOKEN_RE = /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g;
 const JWT_RE = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+const PEM_PRIVATE_KEY_RE = /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/g;
 
 const RESTRICTED_SCHEMES = new Set([
   'about:',
@@ -141,8 +150,14 @@ export function collectReadablePageText(documentLike = globalThis.document, { mi
 
 export function redactSensitiveText(value = '') {
   return String(value || '')
+    .replace(PEM_PRIVATE_KEY_RE, '[REDACTED_PRIVATE_KEY]')
     .replace(BEARER_RE, 'Bearer [REDACTED_BEARER]')
     .replace(OPENAI_STYLE_RE, '[REDACTED_SECRET]')
+    .replace(STRIPE_KEY_RE, '[REDACTED_SECRET]')
+    .replace(AWS_ACCESS_KEY_RE, '[REDACTED_SECRET]')
+    .replace(GITHUB_TOKEN_RE, '[REDACTED_SECRET]')
+    .replace(GOOGLE_API_KEY_RE, '[REDACTED_SECRET]')
+    .replace(SLACK_TOKEN_RE, '[REDACTED_SECRET]')
     .replace(JWT_RE, '[REDACTED_JWT]')
     .replace(SECRET_ASSIGNMENT_RE, (_match, key) => `${key}=[REDACTED_SECRET]`);
 }

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -1447,11 +1447,20 @@ function collectPageContextFallback(options = {}) {
     return `${text.slice(0, limit)}\n\n[truncated ${text.length - limit} chars]`;
   }
   function redact(value) {
+    // Mirror of redactSensitiveText in lib/common.mjs. This function is injected
+    // via chrome.scripting.executeScript and must stay self-contained, so the
+    // patterns are duplicated here; the canonical version lives in lib/common.mjs.
     return String(value || '')
+      .replace(/-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/g, '[REDACTED_PRIVATE_KEY]')
       .replace(/\bBearer\s+[^\s'"`;&]+/gi, 'Bearer [REDACTED_BEARER]')
       .replace(new RegExp('\\bsk-[A-Za-z0-9_\\-]{12,}\\b', 'g'), '[REDACTED_SECRET]')
+      .replace(/\b[sr]k_(?:live|test)_[0-9A-Za-z]{16,}\b/g, '[REDACTED_SECRET]')
+      .replace(/\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g, '[REDACTED_SECRET]')
+      .replace(/\b(?:gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{40,})\b/g, '[REDACTED_SECRET]')
+      .replace(/\bAIza[0-9A-Za-z_\-]{35}\b/g, '[REDACTED_SECRET]')
+      .replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, '[REDACTED_SECRET]')
       .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, '[REDACTED_JWT]')
-      .replace(/\b(api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|secret|private[_-]?key)\b\s*[:=]\s*([^\s'"`;&]+)/gi, (_match, key) => `${key}=[REDACTED_SECRET]`);
+      .replace(/\b(api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|secret|private[_-]?key)\b["'`]?\s*[:=]\s*["'`]?([^\s'"`;&]+)/gi, (_match, key) => `${key}=[REDACTED_SECRET]`);
   }
   function pageMeta() {
     const description = document.querySelector('meta[name="description"], meta[property="og:description"]')?.content || '';

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -43,6 +43,36 @@ test('redactSensitiveText masks obvious tokens and password assignments', () => 
   assert.doesNotMatch(output, /hunter2/);
 });
 
+test('redactSensitiveText masks common provider token shapes and quoted secret values', () => {
+  // Build sensitive literals at runtime so the test file itself never embeds a
+  // token shape that looks real to scanners.
+  const aws = `AKIA${'A1B2C3D4E5F6G7H8'}`;
+  const github = `ghp_${'a'.repeat(36)}`;
+  const githubPat = `github_pat_${'b'.repeat(42)}`;
+  const google = `AIza${'C'.repeat(35)}`;
+  const slack = `xoxb-${'1234567890'}-${'abcdefghij'}`;
+  const stripe = `sk_live_${'0123456789abcdefXYZ'}`;
+  const pem = `-----BEGIN RSA PRIVATE KEY-----\n${'MIIEpAIB'.repeat(3)}\n-----END RSA PRIVATE KEY-----`;
+  const samples = { aws, github, githubPat, google, slack, stripe };
+  for (const [name, secret] of Object.entries(samples)) {
+    const out = redactSensitiveText(`leaked ${name}: ${secret} trailing`);
+    assert.doesNotMatch(out, new RegExp(secret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `${name} should be redacted`);
+    assert.match(out, /\[REDACTED_SECRET\]/, `${name} should produce a redaction marker`);
+  }
+  // PEM private-key blocks collapse to a single marker.
+  const pemOut = redactSensitiveText(pem);
+  assert.match(pemOut, /\[REDACTED_PRIVATE_KEY\]/);
+  assert.doesNotMatch(pemOut, /BEGIN RSA PRIVATE KEY/);
+
+  // Secrets inside quoted JSON/config are redacted, not just bare assignments.
+  const jsonOut = redactSensitiveText('{"api_key": "abc123def456"}');
+  assert.doesNotMatch(jsonOut, /abc123def456/);
+  assert.match(jsonOut, /\[REDACTED_SECRET\]/);
+
+  // Benign prose without a secret marker is left intact.
+  assert.equal(redactSensitiveText('The quick brown fox jumps over the lazy dog.'), 'The quick brown fox jumps over the lazy dog.');
+});
+
 test('clampText preserves short text and clearly marks truncation', () => {
   assert.equal(clampText('short', 10), 'short');
   assert.equal(clampText('abcdefghijklmnop', 8), 'abcdefgh\n\n[truncated 8 chars]');


### PR DESCRIPTION
## What

`redactSensitiveText` (and its two inline copies) only masked `Bearer …`, `sk-…`, JWTs, and bare `key=value` assignments. Two gaps let secrets reach the gateway and persist in session history:

- The assignment value class excluded quotes, so secrets in quoted JSON/config passed straight through — `{"api_key": "abc123"}` was **not** redacted.
- No patterns for common provider tokens (AWS, GitHub, Google, Slack, Stripe, PEM private keys).

## Changes

- Allow an optional quote around the assignment value so quoted JSON/config values are redacted.
- Add patterns for AWS (`AKIA`/`ASIA`), GitHub (`ghp_`/`gho_`/…/`github_pat_`), Google (`AIza…`), Slack (`xox[baprs]-…`), Stripe (`[sr]k_live/test_…`), and PEM `PRIVATE KEY` blocks.
- Mirror the same patterns into the two inline copies that can't import the module: `content.js` and the `executeScript`-injected fallback in `sidepanel.js`.

## Verification

- `npm test` is green. Adds a regression test that builds each secret shape at runtime (so no real-looking token is committed), asserting the secret is gone and a marker is present, plus quoted-JSON and benign-prose cases.
- Negative control: reverting only `lib/common.mjs` to its parent while keeping the new test fails exactly that test, proving it is a real guard.
- All new patterns are linear — adversarial 200k–360k-char inputs each redact in under 2 ms (no catastrophic backtracking).

## Notes / scope

- Redaction stays **best-effort** by design. Out of scope here: the pre-existing over-redaction of prose like `password: please` (unchanged by this diff), and a cosmetic artifact where a redacted quoted value collapses structure (`{"api_key=[REDACTED_SECRET]"}` — the value is fully removed, only the surrounding quoting is cosmetically affected).
- The three copies are duplicated because content scripts and `executeScript`-injected functions cannot import the ESM module; a follow-up could add a test asserting they stay in sync.
