### PR TITLE
fix(sessions): stop dropping sessions when the server returns short pages

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -798,3 +798,15 @@ export function extractAssistantText(payload) {
 export function encodeSessionId(sessionId = DEFAULT_SETTINGS.sessionId) {
   return encodeURIComponent(String(sessionId || DEFAULT_SETTINGS.sessionId).trim() || DEFAULT_SETTINGS.sessionId);
 }
+
+// Decide whether session pagination should stop after consuming a page.
+// `offset` is the running total of rows already consumed (including this page).
+// A page shorter than `limit` is NOT a stop signal on its own: servers can
+// return short pages (e.g. when include_children expands rows) while more
+// pages remain, so we honor the explicit has_more / total signals instead.
+export function shouldStopSessionPaging({ rowCount = 0, offset = 0, total = 0, hasMore = false } = {}) {
+  if (!rowCount) return true;
+  if (hasMore) return false;
+  if (total && offset < total) return false;
+  return true;
+}

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -22,6 +22,7 @@ import {
   reasoningEffortShortLabel,
   renderMarkdown,
   safeTab,
+  shouldStopSessionPaging,
   shouldSubmitComposerKey,
   skillSuggestionsForInput,
 } from './lib/common.mjs';
@@ -1143,7 +1144,7 @@ async function loadAllHermesSessions() {
     const hasMore = Boolean(payload.has_more ?? payload.hasMore ?? payload.pagination?.hasMore);
     const total = Number(payload.total || payload.pagination?.total || 0);
     offset += rows.length;
-    if (!rows.length || (!hasMore && (!total || offset >= total)) || rows.length < limit) break;
+    if (shouldStopSessionPaging({ rowCount: rows.length, offset, total, hasMore })) break;
   }
   return { data: merged };
 }

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -20,6 +20,7 @@ import {
   normalizeHermesSkills,
   redactSensitiveText,
   renderMarkdown,
+  shouldStopSessionPaging,
   skillCommandForName,
   skillSuggestionsForInput,
   shouldSubmitComposerKey,
@@ -231,4 +232,15 @@ test('YouTube transcript helpers parse ids, providers, timedtext, and prompt tex
   const transcript = normalizeTranscriptPayload({ segments }, 'default-timedtext');
   assert.equal(transcript.ok, true);
   assert.match(formatYoutubeTranscript(transcript), /\[0:01\] hello & world/);
+});
+
+test('shouldStopSessionPaging keeps paging on a short page when more sessions remain', () => {
+  // Regression: a short page (rows < limit) must NOT end pagination while the
+  // server still reports has_more / unmet total, or sessions get dropped.
+  assert.equal(shouldStopSessionPaging({ rowCount: 300, offset: 800, total: 1200, hasMore: true }), false);
+  assert.equal(shouldStopSessionPaging({ rowCount: 300, offset: 800, total: 1200, hasMore: false }), false);
+  // Stop only when the page is empty, or no more are signalled.
+  assert.equal(shouldStopSessionPaging({ rowCount: 0, offset: 1200, total: 1200, hasMore: true }), true);
+  assert.equal(shouldStopSessionPaging({ rowCount: 200, offset: 1200, total: 1200, hasMore: false }), true);
+  assert.equal(shouldStopSessionPaging({ rowCount: 200, offset: 200, total: 0, hasMore: false }), true);
 });


### PR DESCRIPTION
## What

`loadAllHermesSessions` ended its pagination loop as soon as a page returned fewer than `limit` rows (`rows.length < limit`). With `include_children=true` the gateway can expand rows server-side and return a short page while `has_more`/`total` still indicate more sessions remain — so the session picker silently loaded only a prefix of the user's sessions.

## Changes

Replace the `rows.length < limit` early-stop with an exported `shouldStopSessionPaging` predicate that honors the explicit `has_more`/`total` signals and only stops on an empty page or when no more are reported. The existing 10-page cap and empty-page guard still bound the loop.

## Verification

- `npm test` is green. Adds a unit test for the predicate across the meaningful branches (short page with more remaining, empty page, completed, no signals).
- Negative control: the old inline condition stops on a 300-row page (limit 500) while `total: 1200, has_more: true`, dropping 400 sessions; the new predicate keeps paging. Reverting the source fails the new test.

## Notes

- Bounded: the loop still hard-caps at 10 pages × 500, and an empty page always stops even under `has_more: true`, so there is no infinite-loop risk.
- When `has_more` and `total` disagree, the predicate trusts `has_more` (keeps paging), costing at most one extra fetch that returns empty and then stops.
