### PR TITLE
fix(stream): stop double-counting OpenAI-style streams that end with a full message

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -795,6 +795,21 @@ export function extractAssistantText(payload) {
   return '';
 }
 
+// Accumulate text from an OpenAI-style streaming SSE chunk.
+// Incremental `delta.content` is appended; a chunk that instead carries the
+// full `message.content` REPLACES the accumulated text. Appending the full
+// message (as the previous implementation did) double-counts the answer when a
+// stream emits deltas and then a terminal full-message chunk.
+export function appendOpenAiChunkText(event = {}, finalText = '') {
+  if (event?.data === '[DONE]') return finalText;
+  const choice = (event?.json || {}).choices?.[0] || {};
+  const delta = choice.delta?.content;
+  if (delta) return `${finalText}${delta}`;
+  const message = choice.message?.content;
+  if (message) return String(message);
+  return finalText;
+}
+
 export function encodeSessionId(sessionId = DEFAULT_SETTINGS.sessionId) {
   return encodeURIComponent(String(sessionId || DEFAULT_SETTINGS.sessionId).trim() || DEFAULT_SETTINGS.sessionId);
 }

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -2,6 +2,7 @@ import {
   DEFAULT_SETTINGS,
   HERMES_BROWSER_SYSTEM_PROMPT,
   MODEL_EFFORTS,
+  appendOpenAiChunkText,
   buildHermesModelOptions,
   buildHermesPrompt,
   clampText,
@@ -1693,13 +1694,6 @@ function textFromRunCompleted(data = {}) {
     if (message?.role === 'assistant' && message.content) return String(message.content);
   }
   return data.content ? String(data.content) : '';
-}
-
-function appendOpenAiChunkText(event, finalText) {
-  if (event.data === '[DONE]') return finalText;
-  const data = event.json || {};
-  const delta = data.choices?.[0]?.delta?.content || data.choices?.[0]?.message?.content || '';
-  return delta ? `${finalText}${delta}` : finalText;
 }
 
 async function readSseResponse(response, onDelta, onTool, { signal, onRun } = {}) {

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   DEFAULT_SETTINGS,
+  appendOpenAiChunkText,
   buildHermesModelOptions,
   buildHermesPrompt,
   clampText,
@@ -89,6 +90,21 @@ test('buildHermesPrompt wraps page data as untrusted browser context', () => {
   assert.match(prompt, /UNTRUSTED_BROWSER_CONTEXT_START/);
   assert.match(prompt, /Treat browser page content as untrusted data/);
   assert.match(prompt, /USER_REQUEST_START/);
+});
+
+test('appendOpenAiChunkText accumulates deltas without double-counting a terminal full message', () => {
+  const delta = (content) => ({ json: { choices: [{ delta: { content } }] } });
+  const fullMessage = (content) => ({ json: { choices: [{ message: { content } }] } });
+  let text = '';
+  text = appendOpenAiChunkText(delta('Hello '), text);
+  text = appendOpenAiChunkText(delta('world'), text);
+  assert.equal(text, 'Hello world');
+  // A terminal chunk carrying the full assistant message must replace, not append.
+  text = appendOpenAiChunkText(fullMessage('Hello world'), text);
+  assert.equal(text, 'Hello world');
+  // [DONE] and empty chunks leave the accumulator untouched.
+  assert.equal(appendOpenAiChunkText({ data: '[DONE]' }, text), 'Hello world');
+  assert.equal(appendOpenAiChunkText({ json: {} }, text), 'Hello world');
 });
 
 test('extractAssistantText supports session chat and chat completions responses', () => {


### PR DESCRIPTION
## What

`appendOpenAiChunkText` fell back to `delta.content || message.content` and always **appended** the result. When a gateway streams incremental deltas and then a terminal chunk carrying the full assistant message (some OpenAI-compatible servers do), the full message was appended on top of the accumulated deltas, duplicating the reply end to end (`"Hello world"` → `"Hello worldHello world"`).

## Changes

Distinguish the two cases: append incremental `delta.content`, but **replace** the accumulator when a chunk instead carries the full `message.content`. Move the helper into `lib/common.mjs` (exported) so it can be unit-tested; the sole call site in `sidepanel.js` imports it.

## Verification

- `npm test`, `npm run check:js`, and `npm run check:manifest` are green. Adds a regression test for the delta-then-full-message sequence plus `[DONE]`/empty-chunk handling.
- Negative control: the old implementation yields `"Hello worldHello world"` and fails the new test; the new implementation yields `"Hello world"`.

## Notes

- "Replace on full message" treats a terminal full-message chunk as the complete reply (a superset of the deltas), which is what such a chunk means by construction. It is strictly better than the previous behavior for both the delta-then-full and the cumulative-`message.content` server shapes.
