### PR TITLE
fix(markdown): render GFM tables with single-dash dividers

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -311,7 +311,7 @@ function isHorizontalRule(line = '') {
 }
 
 function isTableDivider(line = '') {
-  return /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(line);
+  return /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$/.test(line);
 }
 
 function tableCells(line = '') {

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -118,6 +118,17 @@ test('renderMarkdown produces safe rich text for headings, lists, tables, and li
   assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
 });
 
+test('renderMarkdown renders GFM tables whose divider uses a single dash per column', () => {
+  const html = renderMarkdown('| Name | Value |\n|-|-|\n| MiniMax | 1M |');
+  assert.match(html, /<table>/);
+  assert.match(html, /<th>Name<\/th>/);
+  assert.match(html, /<th>Value<\/th>/);
+  assert.match(html, /<td>MiniMax<\/td>/);
+  assert.match(html, /<td>1M<\/td>/);
+  // The compact divider must not leak through as a literal paragraph.
+  assert.doesNotMatch(html, /\|-\|-\|/);
+});
+
 test('normalizeHermesModels converts OpenAI-style /v1/models payload and keeps selected fallback', () => {
   const models = normalizeHermesModels({ data: [{ id: 'hermes-agent' }, { id: 'nous/nemotron', context_length: 131072 }] }, 'custom/local');
   assert.deepEqual(models.map((model) => model.id), ['hermes-agent', 'nous/nemotron', 'custom/local']);


### PR DESCRIPTION
## What

`isTableDivider` required at least three dashes per column (`-{3,}`), so a valid GFM table whose divider row is written compactly (e.g. `|-|-|`) was not recognized and fell through to the paragraph renderer — surfacing the raw pipes in the assistant reply.

## Changes

Loosen the divider pattern to one-or-more dashes (`:?-+:?`) while keeping optional alignment colons. Horizontal rules and multi-dash dividers are unaffected (HR is matched earlier and has no pipes).

## Verification

- `npm test` is green. Adds a regression test that the single-dash divider renders a real `<table>` and the raw `|-|-|` does not leak as a paragraph.
- Negative control: reverting the source fails the new test.

## Notes

- Matches GFM, which accepts one-or-more dashes per column. Multi-column tables are still required for promotion (the divider must have ≥2 columns), so a lone `|-|` is not treated as a table.
