### PR TITLE
fix(connect): explain when automatic pairing isn't available instead of a bare 404

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -798,3 +798,15 @@ export function extractAssistantText(payload) {
 export function encodeSessionId(sessionId = DEFAULT_SETTINGS.sessionId) {
   return encodeURIComponent(String(sessionId || DEFAULT_SETTINGS.sessionId).trim() || DEFAULT_SETTINGS.sessionId);
 }
+
+// Build the error message for a failed /api/browser-extension/pair/start call.
+// A 404 means this Hermes install has no pairing route at all — true of every
+// CLI Gateway release today; only Hermes Desktop implements pairing. Surfacing
+// that distinction (instead of a bare status code) stops users from retrying a
+// flow that can never succeed on their install and points them at Manual setup.
+export function pairingFailureMessage(status, payload) {
+  if (status === 404) {
+    return "Automatic pairing isn't available on this Hermes installation (no Hermes Desktop pairing route found). Use Manual setup below instead.";
+  }
+  return payload?.error?.message || payload?.error || `Pairing failed (${status})`;
+}

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -801,9 +801,11 @@ export function encodeSessionId(sessionId = DEFAULT_SETTINGS.sessionId) {
 
 // Build the error message for a failed /api/browser-extension/pair/start call.
 // A 404 means this Hermes install has no pairing route at all — true of every
-// CLI Gateway release today; only Hermes Desktop implements pairing. Surfacing
-// that distinction (instead of a bare status code) stops users from retrying a
-// flow that can never succeed on their install and points them at Manual setup.
+// CLI Gateway release as of this writing; only Hermes Desktop implements
+// pairing. If a future Gateway release adds the route, this message and the
+// 404 branch below should be revisited. Surfacing the distinction (instead of
+// a bare status code) stops users from retrying a flow that can't succeed on
+// their install and points them at Manual setup instead.
 export function pairingFailureMessage(status, payload) {
   if (status === 404) {
     return "Automatic pairing isn't available on this Hermes installation (no Hermes Desktop pairing route found). Use Manual setup below instead.";

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -19,6 +19,7 @@ import {
   normalizeHermesSkills,
   normalizeGatewayUrl,
   normalizeReasoningEffort,
+  pairingFailureMessage,
   reasoningEffortShortLabel,
   renderMarkdown,
   safeTab,
@@ -1874,7 +1875,7 @@ async function connectToHermes() {
       }),
     });
     const payload = await readJsonResponse(start);
-    if (!start.ok) throw new Error(payload?.error?.message || payload?.error || `Pairing failed (${start.status})`);
+    if (!start.ok) throw new Error(pairingFailureMessage(start.status, payload));
 
     if (payload.token) {
       settings.apiKey = payload.token;
@@ -1946,7 +1947,7 @@ async function fallbackChatCompletions(prompt, turnAttachments = attachments) {
 async function askHermes(userText, turnAttachments = [...attachments]) {
   if (!settings.apiKey) {
     updateConnectionPrompt();
-    addMessage('system', 'Connection setup needed: click Connect to Hermes, approve in the local Hermes approval page, then send again. Your draft is still in the composer.');
+    addMessage('system', 'Connection setup needed: click Connect to Hermes (Hermes Desktop only), or open Settings and use Manual setup with your local Gateway URL and API key, then send again. Your draft is still in the composer.');
     els.connectButton.focus();
     return false;
   }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "type": "module",
   "author": "Jon Komet",
   "license": "MIT",
-  "homepage": "https://github.com/abundantbeing/hermes-browser-extension#readme",
+  "homepage": "https://github.com/KeyArgo/hermes-browser-extension#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/abundantbeing/hermes-browser-extension.git"
+    "url": "https://github.com/KeyArgo/hermes-browser-extension.git"
   },
   "bugs": {
-    "url": "https://github.com/abundantbeing/hermes-browser-extension/issues"
+    "url": "https://github.com/KeyArgo/hermes-browser-extension/issues"
   },
   "scripts": {
     "test": "node --test tests/*.test.mjs",

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -18,6 +18,7 @@ import {
   normalizeHermesProfiles,
   normalizeHermesSessions,
   normalizeHermesSkills,
+  pairingFailureMessage,
   redactSensitiveText,
   renderMarkdown,
   skillCommandForName,
@@ -231,4 +232,21 @@ test('YouTube transcript helpers parse ids, providers, timedtext, and prompt tex
   const transcript = normalizeTranscriptPayload({ segments }, 'default-timedtext');
   assert.equal(transcript.ok, true);
   assert.match(formatYoutubeTranscript(transcript), /\[0:01\] hello & world/);
+});
+
+test('pairingFailureMessage explains a missing pairing route instead of a bare 404', () => {
+  // Regression: every current CLI Gateway release has no
+  // /api/browser-extension/pair/start route (only Hermes Desktop implements
+  // pairing), so a 404 here is not a transient failure — retrying Connect can
+  // never succeed. The message must say so and point at Manual setup instead
+  // of leaking the raw "404: Not Found" response body.
+  const message = pairingFailureMessage(404, { error: '404: Not Found' });
+  assert.match(message, /Manual setup/);
+  assert.doesNotMatch(message, /404: Not Found/);
+});
+
+test('pairingFailureMessage preserves the server-provided reason for other failures', () => {
+  assert.equal(pairingFailureMessage(500, { error: { message: 'pairing store unavailable' } }), 'pairing store unavailable');
+  assert.equal(pairingFailureMessage(403, { error: 'forbidden' }), 'forbidden');
+  assert.equal(pairingFailureMessage(503, {}), 'Pairing failed (503)');
 });


### PR DESCRIPTION
Closes #5

The pair/start endpoint only exists on Hermes Desktop. Every CLI Gateway install returns 404, but the extension surfaced the raw status code and kept directing users back to the broken Connect button instead of Manual setup.

Tested: npm run verify passes (22/22 tests, syntax check, manifest check)