### PR TITLE
fix(sessions): stop short pages from ending pagination early

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -798,3 +798,16 @@ export function extractAssistantText(payload) {
 export function encodeSessionId(sessionId = DEFAULT_SETTINGS.sessionId) {
   return encodeURIComponent(String(sessionId || DEFAULT_SETTINGS.sessionId).trim() || DEFAULT_SETTINGS.sessionId);
 }
+
+// Whether a /api/sessions page fetch is the last one needed. A page shorter
+// than the requested limit is NOT on its own proof that no rows remain: a
+// server can return a short page (e.g. when include_children expands some
+// rows into more than one returned item per row) while more pages exist, so
+// this only trusts the page being empty or the server's own more/total
+// signals — never the page length relative to the requested limit.
+export function isLastSessionPage({ pageRowCount = 0, totalFetched = 0, totalAvailable = 0, serverSaysMore = false } = {}) {
+  if (pageRowCount === 0) return true;
+  if (serverSaysMore) return false;
+  if (totalAvailable > 0 && totalFetched < totalAvailable) return false;
+  return true;
+}

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -12,6 +12,7 @@ import {
   formatContextMeter,
   groupModelsForMenu,
   groupSessionsForMenu,
+  isLastSessionPage,
   isRestrictedUrl,
   normalizeHermesModels,
   normalizeHermesProfiles,
@@ -1143,7 +1144,7 @@ async function loadAllHermesSessions() {
     const hasMore = Boolean(payload.has_more ?? payload.hasMore ?? payload.pagination?.hasMore);
     const total = Number(payload.total || payload.pagination?.total || 0);
     offset += rows.length;
-    if (!rows.length || (!hasMore && (!total || offset >= total)) || rows.length < limit) break;
+    if (isLastSessionPage({ pageRowCount: rows.length, totalFetched: offset, totalAvailable: total, serverSaysMore: hasMore })) break;
   }
   return { data: merged };
 }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "type": "module",
   "author": "Jon Komet",
   "license": "MIT",
-  "homepage": "https://github.com/abundantbeing/hermes-browser-extension#readme",
+  "homepage": "https://github.com/KeyArgo/hermes-browser-extension#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/abundantbeing/hermes-browser-extension.git"
+    "url": "https://github.com/KeyArgo/hermes-browser-extension.git"
   },
   "bugs": {
-    "url": "https://github.com/abundantbeing/hermes-browser-extension/issues"
+    "url": "https://github.com/KeyArgo/hermes-browser-extension/issues"
   },
   "scripts": {
     "test": "node --test tests/*.test.mjs",

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -13,6 +13,7 @@ import {
   formatYoutubeTranscript,
   groupModelsForMenu,
   groupSessionsForMenu,
+  isLastSessionPage,
   isRestrictedUrl,
   normalizeHermesModels,
   normalizeHermesProfiles,
@@ -231,4 +232,15 @@ test('YouTube transcript helpers parse ids, providers, timedtext, and prompt tex
   const transcript = normalizeTranscriptPayload({ segments }, 'default-timedtext');
   assert.equal(transcript.ok, true);
   assert.match(formatYoutubeTranscript(transcript), /\[0:01\] hello & world/);
+});
+
+test('isLastSessionPage keeps paging through a short page when the server reports more remain', () => {
+  // Regression: a page shorter than the requested limit must not end
+  // pagination on its own while has_more/total say otherwise, or sessions
+  // past that page get silently dropped.
+  assert.equal(isLastSessionPage({ pageRowCount: 300, totalFetched: 800, totalAvailable: 1200, serverSaysMore: true }), false);
+  assert.equal(isLastSessionPage({ pageRowCount: 300, totalFetched: 800, totalAvailable: 1200, serverSaysMore: false }), false);
+  assert.equal(isLastSessionPage({ pageRowCount: 0, totalFetched: 1200, totalAvailable: 1200, serverSaysMore: true }), true);
+  assert.equal(isLastSessionPage({ pageRowCount: 200, totalFetched: 1200, totalAvailable: 1200, serverSaysMore: false }), true);
+  assert.equal(isLastSessionPage({ pageRowCount: 200, totalFetched: 200, totalAvailable: 0, serverSaysMore: false }), true);
 });


### PR DESCRIPTION
Closes #9

Replaces the rows.length < limit early-break with isLastSessionPage(), which only stops paging when the page is empty or the server's own has_more/total signals say no rows remain — never based on the page being shorter than the requested limit.

Tested: npm run verify passes (21/21 tests, syntax check, manifest check)