### PR TITLE
fix(stream): stop double-counting a terminal full-message SSE chunk

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -798,3 +798,21 @@ export function extractAssistantText(payload) {
 export function encodeSessionId(sessionId = DEFAULT_SETTINGS.sessionId) {
   return encodeURIComponent(String(sessionId || DEFAULT_SETTINGS.sessionId).trim() || DEFAULT_SETTINGS.sessionId);
 }
+
+// Fold one OpenAI-style SSE chunk into the running accumulated text.
+// choices[0].delta.content is an incremental piece and must be appended.
+// choices[0].message.content is different: some servers emit one terminal
+// chunk shaped like a full message (not a delta) containing the *entire*
+// response so far. That must REPLACE the running total, not append to it —
+// appending duplicates everything already streamed in as deltas onto the end
+// of the response.
+export function mergeOpenAiChunkIntoText(event, accumulatedText) {
+  if (event?.data === '[DONE]') return accumulatedText;
+  const choice = event?.json?.choices?.[0];
+  if (!choice) return accumulatedText;
+  const delta = choice.delta?.content;
+  if (delta) return `${accumulatedText}${delta}`;
+  const fullMessage = choice.message?.content;
+  if (fullMessage) return String(fullMessage);
+  return accumulatedText;
+}

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -13,6 +13,7 @@ import {
   groupModelsForMenu,
   groupSessionsForMenu,
   isRestrictedUrl,
+  mergeOpenAiChunkIntoText,
   normalizeHermesModels,
   normalizeHermesProfiles,
   normalizeHermesSessions,
@@ -1695,13 +1696,6 @@ function textFromRunCompleted(data = {}) {
   return data.content ? String(data.content) : '';
 }
 
-function appendOpenAiChunkText(event, finalText) {
-  if (event.data === '[DONE]') return finalText;
-  const data = event.json || {};
-  const delta = data.choices?.[0]?.delta?.content || data.choices?.[0]?.message?.content || '';
-  return delta ? `${finalText}${delta}` : finalText;
-}
-
 async function readSseResponse(response, onDelta, onTool, { signal, onRun } = {}) {
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
@@ -1726,7 +1720,7 @@ async function readSseResponse(response, onDelta, onTool, { signal, onRun } = {}
         onDelta(finalText);
       }
     } else if (event.type === 'chat.completion.chunk' || event.type === 'message') {
-      const nextText = appendOpenAiChunkText(event, finalText);
+      const nextText = mergeOpenAiChunkIntoText(event, finalText);
       if (nextText !== finalText) {
         finalText = nextText;
         onDelta(finalText);

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "type": "module",
   "author": "Jon Komet",
   "license": "MIT",
-  "homepage": "https://github.com/abundantbeing/hermes-browser-extension#readme",
+  "homepage": "https://github.com/KeyArgo/hermes-browser-extension#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/abundantbeing/hermes-browser-extension.git"
+    "url": "https://github.com/KeyArgo/hermes-browser-extension.git"
   },
   "bugs": {
-    "url": "https://github.com/abundantbeing/hermes-browser-extension/issues"
+    "url": "https://github.com/KeyArgo/hermes-browser-extension/issues"
   },
   "scripts": {
     "test": "node --test tests/*.test.mjs",

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -14,6 +14,7 @@ import {
   groupModelsForMenu,
   groupSessionsForMenu,
   isRestrictedUrl,
+  mergeOpenAiChunkIntoText,
   normalizeHermesModels,
   normalizeHermesProfiles,
   normalizeHermesSessions,
@@ -231,4 +232,24 @@ test('YouTube transcript helpers parse ids, providers, timedtext, and prompt tex
   const transcript = normalizeTranscriptPayload({ segments }, 'default-timedtext');
   assert.equal(transcript.ok, true);
   assert.match(formatYoutubeTranscript(transcript), /\[0:01\] hello & world/);
+});
+
+test('mergeOpenAiChunkIntoText does not duplicate a terminal full-message chunk onto streamed deltas', () => {
+  // Regression: some OpenAI-style SSE streams end with one chunk shaped like
+  // a full message (choices[0].message.content) instead of a final delta.
+  // That chunk is the whole response so far and must replace the running
+  // text, not get appended on top of the deltas already accumulated.
+  const delta = (text) => ({ json: { choices: [{ delta: { content: text } }] } });
+  const fullMessage = (text) => ({ json: { choices: [{ message: { content: text } }] } });
+
+  let text = '';
+  text = mergeOpenAiChunkIntoText(delta('Hello '), text);
+  text = mergeOpenAiChunkIntoText(delta('world'), text);
+  assert.equal(text, 'Hello world');
+
+  text = mergeOpenAiChunkIntoText(fullMessage('Hello world'), text);
+  assert.equal(text, 'Hello world');
+
+  assert.equal(mergeOpenAiChunkIntoText({ data: '[DONE]' }, text), 'Hello world');
+  assert.equal(mergeOpenAiChunkIntoText({ json: {} }, text), 'Hello world');
 });


### PR DESCRIPTION
Closes #11

Replaces appendOpenAiChunkText with mergeOpenAiChunkIntoText, which appends choices[0].delta.content as before but replaces (rather than appends) the running text when a chunk instead carries choices[0].message.content, since that shape is the entire response so far, not an incremental delta.

Tested: npm run verify passes (21/21 tests, syntax check, manifest check)