### PR TITLE
Add a remote-dashboard gateway mode (WebSocket, no API server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ In the side panel first-run screen:
 1. Click **Connect to Hermes** and approve locally if your Hermes Desktop/gateway supports the approval flow.
 2. If approval is not available yet, click **Manual setup**.
 3. Enter:
-   - Gateway mode: **Local API server** or **Remote API server**.
+   - Gateway: **Local** or **Remote**. In Remote, paste an API key to use a remote API server, or leave it blank to connect over the dashboard WebSocket.
    - Gateway URL: `http://127.0.0.1:8642`, `http://<tailscale-ip>:8642`, or your HTTPS reverse-proxy URL.
    - API key / browser token: your scoped browser token or `API_SERVER_KEY`.
    - Session ID: `hermes-browser-extension`
@@ -127,6 +127,18 @@ After connection, the side panel automatically loads from the connected Hermes g
 - `/v1/capabilities` — feature flags such as audio transcription and Browser upload support.
 
 The DOM/context chip should show a non-zero page-context count on normal readable pages. Browser internal pages such as `chrome://extensions` are intentionally restricted.
+
+### Remote dashboard mode (no API server)
+
+If you run Hermes elsewhere and only expose the OAuth-gated dashboard (not the API server), select **Remote**, enter the dashboard's https URL, and leave the API key blank. With no key the extension connects over the dashboard's `/api/ws` socket instead of the REST API server, so you don't have to enable or expose `API_SERVER_*` at all. (Paste a key and it uses a remote API server instead.)
+
+Auth uses a single-use WebSocket ticket minted from a signed-in dashboard tab:
+
+- Open the dashboard URL in a normal browser tab and sign in, and keep that tab around.
+- The extension mints the ticket first-party from that tab (the dashboard's CORS and `SameSite=Lax` cookie make a direct cross-origin mint impossible), then opens the socket. No API key is used.
+- **Test connection** opens the socket and loads models, which confirms the whole path. Sessions list, open, and create over the socket too.
+
+Limitations in this mode: image attachments are inline-only, and the skills/profiles lists are unavailable, because those are REST-only and the dashboard's REST surface is not reachable cross-origin.
 
 ## Install with Hermes / Computer Use
 

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -11,6 +11,12 @@ export const GATEWAY_MODES = Object.freeze([
     title: 'Remote Hermes API server',
     defaultUrl: 'https://your-hermes-host.example.com',
   },
+  {
+    value: 'remote-dashboard',
+    label: 'Remote dashboard (WebSocket)',
+    title: 'Remote Hermes dashboard',
+    defaultUrl: 'https://your-hermes-host.example.com',
+  },
 ]);
 
 export const MODEL_EFFORTS = Object.freeze([
@@ -115,15 +121,30 @@ export function normalizedExtensionOrigin(value = '') {
   return String(value || '').trim().replace(/\/+$/, '');
 }
 
+// The remote-dashboard WebSocket is reachable from the (secure-context) side
+// panel only over https. Plain http to a non-loopback host is mixed-content
+// blocked, and a bare host like "example.com" fails to parse, so neither counts.
+export function isUsableRemoteGatewayUrl(value = '') {
+  try {
+    return new URL(String(value || '')).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export function gatewayConnectionSummary({ gatewayMode = DEFAULT_SETTINGS.gatewayMode, gatewayUrl = DEFAULT_SETTINGS.gatewayUrl, extensionOrigin = '' } = {}) {
   const mode = gatewayModeDetails(gatewayMode);
   const normalizedUrl = normalizeGatewayUrl(gatewayUrl || mode.defaultUrl || DEFAULT_SETTINGS.gatewayUrl);
   const origin = normalizedExtensionOrigin(extensionOrigin);
   const corsOrigin = origin || 'chrome-extension://<extension-id>';
-  const isRemote = mode.value === 'remote-api';
-  const setupHint = isRemote
-    ? `Remote Hermes API setup: run the API server on the host machine with API_SERVER_ENABLED=true, API_SERVER_HOST=0.0.0.0, API_SERVER_PORT=8642, API_SERVER_KEY=<strong-token>, and API_SERVER_CORS_ORIGINS=${corsOrigin}. Put it behind Tailscale/VPN/HTTPS instead of exposing it naked to the public internet.`
-    : 'Local setup: keep Hermes Gateway/API Server running on this machine. Default URL is http://127.0.0.1:8642 and auth uses a scoped browser token or API_SERVER_KEY for manual setup.';
+  let setupHint;
+  if (mode.value === 'remote-dashboard') {
+    setupHint = 'Remote dashboard over WebSocket. Sign in to it in a browser tab. No key needed. Add a key to use an API server instead.';
+  } else if (mode.value === 'remote-api') {
+    setupHint = `Remote API server. Set API_SERVER_KEY and API_SERVER_CORS_ORIGINS=${corsOrigin} on the host. Clear the key to use the dashboard instead.`;
+  } else {
+    setupHint = 'Local API server (default http://127.0.0.1:8642). Paste its key below.';
+  }
   return {
     mode,
     normalizedUrl,

--- a/extension/lib/dashboard-bridge.mjs
+++ b/extension/lib/dashboard-bridge.mjs
@@ -1,0 +1,114 @@
+// Ticket broker for the OAuth-gated dashboard.
+//
+// The dashboard mints a WebSocket ticket only on a cookie-authenticated
+// POST /api/auth/ws-ticket. From a chrome-extension:// origin that request is
+// cross-site: the dashboard's CORS rejects the extension origin and its
+// SameSite=Lax session cookie isn't sent. So instead of calling it directly,
+// we run the mint INSIDE a logged-in dashboard tab via chrome.scripting — there
+// the fetch is first-party (same-origin cookie rides, no foreign CORS).
+//
+// The chrome APIs are injected so the broker logic is unit-testable. The in-page
+// mint function (mintTicketInPage) must stay self-contained: chrome.scripting
+// serializes it and runs it in the page, so it cannot close over module scope.
+
+export function originOf(url) {
+  try {
+    return new URL(String(url || '')).origin;
+  } catch {
+    return '';
+  }
+}
+
+export function wsTicketUrl(baseUrl) {
+  // Build from a parsed URL so a pasted address with a query/hash (e.g.
+  // copied from the address bar) does not produce ".../hermes?x=1/api/...".
+  try {
+    const url = new URL(String(baseUrl || ''));
+    url.hash = '';
+    url.search = '';
+    url.pathname = `${url.pathname.replace(/\/+$/, '')}/api/auth/ws-ticket`;
+    return url.toString();
+  } catch {
+    return `${String(baseUrl || '').replace(/\/+$/, '')}/api/auth/ws-ticket`;
+  }
+}
+
+// Runs in the dashboard page. Returns a structured result rather than throwing
+// so the caller can branch on `reason` (e.g. prompt the user to sign in).
+export async function mintTicketInPage(ticketUrl) {
+  try {
+    const response = await fetch(ticketUrl, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+    if (response.status === 401 || response.status === 403) {
+      return { ok: false, reason: 'not_signed_in', status: response.status };
+    }
+    if (!response.ok) {
+      return { ok: false, reason: `ticket_http_${response.status}`, status: response.status };
+    }
+    const data = await response.json().catch(() => null);
+    if (!data || !data.ticket) return { ok: false, reason: 'no_ticket_in_response' };
+    return { ok: true, ticket: data.ticket, ttlSeconds: Number(data.ttl_seconds || 0) };
+  } catch (error) {
+    return { ok: false, reason: 'fetch_failed', detail: String(error?.message || error) };
+  }
+}
+
+// Find a loaded, non-discarded tab on the dashboard origin that can run the
+// first-party mint. Returns the tab or null.
+export async function findDashboardTab(tabsApi, origin) {
+  if (!origin || !tabsApi?.query) return null;
+  let tabs = [];
+  try {
+    tabs = await tabsApi.query({ url: `${origin}/*` });
+  } catch {
+    return null;
+  }
+  const usable = (tabs || []).filter(
+    (tab) => tab && tab.id != null && !tab.discarded && originOf(tab.url) === origin,
+  );
+  return usable[0] || null;
+}
+
+// Mint a fresh ws-ticket (single-use, ~30s TTL) by executing the mint in a
+// logged-in dashboard tab. Returns the mintTicketInPage result shape, plus
+// { ok:false, reason:'no_dashboard_tab', origin } when no usable tab exists so
+// the caller can tell the user to open + sign in to the dashboard.
+export async function mintWsTicket({ tabsApi, scriptingApi, baseUrl, mintFn = mintTicketInPage }) {
+  const origin = originOf(baseUrl);
+  if (!origin) return { ok: false, reason: 'bad_base_url' };
+  if (!scriptingApi?.executeScript) return { ok: false, reason: 'scripting_unavailable' };
+
+  const tab = await findDashboardTab(tabsApi, origin);
+  if (!tab?.id) return { ok: false, reason: 'no_dashboard_tab', origin };
+
+  let injection;
+  try {
+    [injection] = await scriptingApi.executeScript({
+      target: { tabId: tab.id },
+      func: mintFn,
+      args: [wsTicketUrl(baseUrl)],
+    });
+  } catch (error) {
+    return { ok: false, reason: 'inject_failed', detail: String(error?.message || error) };
+  }
+  return injection?.result || { ok: false, reason: 'no_result' };
+}
+
+// Human-facing message for a mint failure reason.
+export function ticketFailureHelp(reason = '', origin = '') {
+  switch (reason) {
+    case 'no_dashboard_tab':
+      return `Open ${origin || 'your Hermes dashboard'} in a tab and sign in, then try connecting again.`;
+    case 'not_signed_in':
+      return 'Your Hermes dashboard tab is not signed in. Sign in there, then try connecting again.';
+    case 'bad_base_url':
+      return 'The remote gateway URL is not a valid https URL.';
+    case 'scripting_unavailable':
+      return 'This extension context cannot mint a dashboard ticket.';
+    default:
+      return `Could not get a dashboard WebSocket ticket (${reason || 'unknown'}).`;
+  }
+}

--- a/extension/lib/gateway-ws.mjs
+++ b/extension/lib/gateway-ws.mjs
@@ -1,0 +1,202 @@
+// JSON-RPC 2.0 over WebSocket client for the Hermes dashboard gateway (/api/ws).
+//
+// This is the transport the desktop app uses. The browser extension uses it
+// only in remote mode against an OAuth-gated dashboard, where the REST/SSE
+// api_server surface is unavailable. Auth is a single-use ws-ticket appended to
+// the URL; the ticket itself is minted first-party (see the dashboard bridge in
+// sidepanel.js) because the dashboard's CORS rejects the extension origin.
+//
+// The pure helpers (URL building, frame classification) are exported separately
+// so they can be unit-tested without a live socket.
+
+export const WS_METHODS = Object.freeze({
+  sessionCreate: 'session.create',
+  sessionResume: 'session.resume',
+  sessionList: 'session.list',
+  sessionHistory: 'session.history',
+  sessionInfo: 'session.info',
+  promptSubmit: 'prompt.submit',
+  sessionInterrupt: 'session.interrupt',
+  modelOptions: 'model.options',
+});
+
+// Streamed assistant-turn events we care about. Everything else (tool.*,
+// reasoning.*, status.*) is surfaced to listeners but not required for chat.
+export const WS_EVENTS = Object.freeze({
+  ready: 'gateway.ready',
+  messageStart: 'message.start',
+  messageDelta: 'message.delta',
+  messageComplete: 'message.complete',
+  error: 'error',
+});
+
+export function buildDashboardWsUrl(baseUrl, ticket) {
+  const parsed = new URL(String(baseUrl || ''));
+  const scheme = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
+  const prefix = parsed.pathname.replace(/\/+$/, '');
+  return `${scheme}//${parsed.host}${prefix}/api/ws?ticket=${encodeURIComponent(String(ticket || ''))}`;
+}
+
+// Classify an inbound frame so callers don't reimplement the JSON-RPC shape.
+// Returns one of:
+//   { kind: 'response', id, result }        — RPC reply (success)
+//   { kind: 'error', id, error }            — RPC reply (failure)
+//   { kind: 'event', type, sessionId, payload } — server push (method === 'event')
+//   { kind: 'ignore' }                      — unparseable / unrecognized
+export function classifyGatewayFrame(raw) {
+  let frame;
+  try {
+    frame = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  } catch {
+    return { kind: 'ignore' };
+  }
+  if (!frame || typeof frame !== 'object') return { kind: 'ignore' };
+
+  if (frame.id !== undefined && frame.id !== null && frame.method === undefined) {
+    if (frame.error) return { kind: 'error', id: frame.id, error: frame.error };
+    return { kind: 'response', id: frame.id, result: frame.result };
+  }
+
+  if (frame.method === 'event' && frame.params?.type) {
+    return {
+      kind: 'event',
+      type: frame.params.type,
+      sessionId: frame.params.session_id || '',
+      payload: frame.params.payload || {},
+    };
+  }
+
+  return { kind: 'ignore' };
+}
+
+// Minimal JSON-RPC client over a WebSocket. WebSocketImpl is injectable so the
+// client can be unit-tested with a fake socket.
+export function createGatewayClient({ WebSocketImpl, requestTimeoutMs = 30_000 } = {}) {
+  const SocketCtor = WebSocketImpl || (typeof WebSocket !== 'undefined' ? WebSocket : null);
+  let socket = null;
+  let nextId = 1;
+  const pending = new Map();
+  const listeners = new Map();
+
+  function emit(type, event) {
+    for (const handler of listeners.get(type) || []) {
+      try {
+        handler(event);
+      } catch {
+        // A listener throwing must not break frame dispatch.
+      }
+    }
+    for (const handler of listeners.get('*') || []) {
+      try {
+        handler({ type, ...event });
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  function handleFrame(raw) {
+    const frame = classifyGatewayFrame(raw);
+    if (frame.kind === 'response' || frame.kind === 'error') {
+      const call = pending.get(frame.id);
+      if (!call) return;
+      pending.delete(frame.id);
+      clearTimeout(call.timer);
+      if (frame.kind === 'error') call.reject(new Error(frame.error?.message || 'Gateway RPC failed'));
+      else call.resolve(frame.result);
+      return;
+    }
+    if (frame.kind === 'event') {
+      emit(frame.type, { type: frame.type, sessionId: frame.sessionId, payload: frame.payload });
+    }
+  }
+
+  function rejectAllPending(error) {
+    for (const [, call] of pending) {
+      clearTimeout(call.timer);
+      call.reject(error);
+    }
+    pending.clear();
+  }
+
+  function connect(url) {
+    if (!SocketCtor) return Promise.reject(new Error('WebSocket is not available in this context'));
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      try {
+        socket = new SocketCtor(url);
+      } catch (error) {
+        reject(error);
+        return;
+      }
+      socket.addEventListener('open', () => {
+        settled = true;
+        resolve();
+      });
+      socket.addEventListener('message', (event) => handleFrame(event.data));
+      // Defer to 'close' for the rejection so the close code/reason is reported
+      // (a pre-accept server rejection surfaces as code 1006 with no frame).
+      socket.addEventListener('error', () => {});
+      socket.addEventListener('close', (event) => {
+        if (!settled) {
+          settled = true;
+          const code = event?.code ?? '?';
+          const reason = event?.reason ? `: ${event.reason}` : '';
+          reject(new Error(`WebSocket closed before open (code ${code}${reason})`));
+          return;
+        }
+        rejectAllPending(new Error('WebSocket closed'));
+        emit('close', { type: 'close', payload: { code: event?.code, reason: event?.reason } });
+      });
+    });
+  }
+
+  function request(method, params = {}) {
+    return new Promise((resolve, reject) => {
+      if (!socket || socket.readyState !== 1) {
+        reject(new Error('WebSocket is not open'));
+        return;
+      }
+      const id = nextId;
+      nextId += 1;
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`Gateway RPC ${method} timed out`));
+      }, requestTimeoutMs);
+      pending.set(id, { resolve, reject, timer });
+      try {
+        socket.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }));
+      } catch (error) {
+        pending.delete(id);
+        clearTimeout(timer);
+        reject(error);
+      }
+    });
+  }
+
+  function on(type, handler) {
+    if (!listeners.has(type)) listeners.set(type, new Set());
+    listeners.get(type).add(handler);
+    return () => listeners.get(type)?.delete(handler);
+  }
+
+  function close() {
+    rejectAllPending(new Error('client closed'));
+    try {
+      socket?.close();
+    } catch {
+      /* ignore */
+    }
+    socket = null;
+  }
+
+  return {
+    connect,
+    request,
+    on,
+    close,
+    get readyState() {
+      return socket?.readyState ?? -1;
+    },
+  };
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -56,6 +56,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src http: https:;"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src http: https: wss:;"
   }
 }

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -1046,6 +1046,16 @@ textarea:focus, input:focus, select:focus { border-color: var(--hermes-accent); 
   line-height: 1;
 }
 .secondary { background: var(--hermes-paper); color: var(--hermes-ink); }
+#testConnectionButton.success {
+  background: rgba(var(--hermes-accent-rgb), 0.18);
+  color: var(--hermes-ink);
+  border-color: var(--hermes-accent);
+}
+#testConnectionButton.error {
+  background: rgba(255, 77, 114, 0.16);
+  color: var(--hermes-ink);
+  border-color: var(--danger);
+}
 #sendButton, #saveSettingsButton, #connectButton { background: var(--hermes-primary-bg); color: var(--hermes-primary-fg); border-color: var(--hermes-primary-border); }
 #sendButton:hover, #saveSettingsButton:hover, #connectButton:hover { background: var(--hermes-paper); color: var(--hermes-ink); border-color: var(--hermes-line-strong); }
 
@@ -1505,6 +1515,34 @@ textarea:focus, input:focus, select:focus { border-color: var(--hermes-accent); 
   background: var(--hermes-primary-bg);
   color: var(--hermes-primary-fg);
 }
+.gateway-mode {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  margin-bottom: 4px;
+}
+.conn-mode-card {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--hermes-line);
+  background: var(--hermes-paper);
+  color: var(--hermes-ink);
+  padding: 9px 10px;
+  text-align: left;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.conn-mode-card:hover,
+.conn-mode-card.selected {
+  border-color: var(--hermes-accent);
+  box-shadow: inset 0 0 0 1px var(--hermes-accent);
+}
+.conn-mode-head { display: flex; align-items: center; gap: 6px; }
+.conn-mode-title { font-size: 11px; font-weight: 600; }
+.conn-mode-check { margin-left: auto; color: var(--hermes-accent); font-size: 11px; line-height: 1; }
+.conn-mode-card.selected .conn-mode-check::after { content: "\2713"; }
+.conn-mode-desc { font-size: 9.5px; line-height: 1.3; color: var(--hermes-muted); }
+#gatewayHelp { overflow-wrap: anywhere; }
 .theme-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -239,13 +239,21 @@
             </div>
           </div>
 
-        <label>
-          Gateway mode
-          <select id="gatewayModeInput" name="gatewayMode">
-            <option value="local-api">Local API server on this machine</option>
-            <option value="remote-api">Remote API server on another machine</option>
+        <div class="gateway-mode" role="radiogroup" aria-label="Gateway location">
+          <button class="conn-mode-card" type="button" data-gateway-location="local" role="radio" aria-checked="true">
+            <span class="conn-mode-head"><span class="conn-mode-title">Local gateway</span><span class="conn-mode-check" aria-hidden="true"></span></span>
+            <span class="conn-mode-desc">Hermes on this machine. The default, works offline.</span>
+          </button>
+          <button class="conn-mode-card" type="button" data-gateway-location="remote" role="radio" aria-checked="false">
+            <span class="conn-mode-head"><span class="conn-mode-title">Remote gateway</span><span class="conn-mode-check" aria-hidden="true"></span></span>
+            <span class="conn-mode-desc">Hermes on another machine, reached over https.</span>
+          </button>
+          <select id="gatewayModeInput" name="gatewayMode" hidden>
+            <option value="local-api">Local API server</option>
+            <option value="remote-api">Remote API server</option>
+            <option value="remote-dashboard">Remote dashboard (WebSocket)</option>
           </select>
-        </label>
+        </div>
 
         <label>
           Gateway URL
@@ -255,7 +263,7 @@
 
         <label>
           API key / browser token
-          <input id="apiKeyInput" name="apiKey" type="password" autocomplete="off" placeholder="Connect automatically or paste API_SERVER_KEY" />
+          <input id="apiKeyInput" name="apiKey" type="password" autocomplete="off" placeholder="API key (blank = dashboard)" />
         </label>
 
         <label>

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -19,6 +19,7 @@ import {
   groupSessionsForMenu,
   isMicrophonePermissionError,
   isRestrictedUrl,
+  isUsableRemoteGatewayUrl,
   microphonePermissionHelp,
   modelDisplayName,
   normalizeHermesModels,
@@ -38,6 +39,8 @@ import {
   skillSuggestionsForInput,
 } from './lib/common.mjs';
 import { extractYouTubeVideoId } from './lib/transcript.mjs';
+import { buildDashboardWsUrl, createGatewayClient, WS_EVENTS, WS_METHODS } from './lib/gateway-ws.mjs';
+import { mintWsTicket, ticketFailureHelp } from './lib/dashboard-bridge.mjs';
 
 const $ = (selector) => document.querySelector(selector);
 
@@ -106,6 +109,7 @@ const els = {
   contextPopover: $('#contextPopover'),
   contextBreakdown: $('#contextBreakdown'),
   gatewayModeInput: $('#gatewayModeInput'),
+  remoteTransportRow: $('#remoteTransportRow'),
   gatewayUrlInput: $('#gatewayUrlInput'),
   gatewayHelp: $('#gatewayHelp'),
   apiKeyInput: $('#apiKeyInput'),
@@ -147,6 +151,27 @@ let dictating = false;
 let dictationBaseText = '';
 let dictationFinalText = '';
 let sessionRoutesAvailable = null;
+// The remote-dashboard gateway mode talks to the OAuth-gated dashboard over its
+// /api/ws JSON-RPC socket (the api_server REST/SSE surface is unavailable
+// cross-origin). This holds the live socket + the dashboard-assigned session id.
+let remoteWsConnection = null;
+
+// remote-dashboard mode authenticates over the dashboard WebSocket with a
+// first-party ticket; the other modes (local-api, remote-api) use the REST
+// api_server with a Bearer key.
+function isRemoteWsMode() {
+  return normalizeGatewayMode(settings.gatewayMode) === 'remote-dashboard';
+}
+
+function isRemoteMode() {
+  return normalizeGatewayMode(settings.gatewayMode) !== 'local-api';
+}
+
+function isConnected() {
+  if (!isRemoteMode()) return Boolean(settings.apiKey);        // local: needs an API key
+  if (isRemoteWsMode()) return isUsableRemoteGatewayUrl(settings.gatewayUrl); // dashboard: needs an https URL
+  return Boolean(settings.apiKey) && isUsableRemoteGatewayUrl(settings.gatewayUrl); // remote API: needs both
+}
 
 function setStatus(kind, title, detail) {
   els.statusDot.className = `status-dot ${kind || ''}`.trim();
@@ -204,6 +229,37 @@ function renderGatewayHelp() {
   if (els.gatewayUrlInput) els.gatewayUrlInput.placeholder = summary.mode.defaultUrl || DEFAULT_SETTINGS.gatewayUrl;
 }
 
+// The gateway mode is stored as a flat value (local-api/remote-api/
+// remote-dashboard) but the UI only asks one thing: Local or Remote. For
+// Remote, the transport is inferred from the API key field — a key present
+// means a remote API server, a blank key means the dashboard WebSocket. A
+// hidden <select> (#gatewayModeInput) stays the source of truth so the rest of
+// the settings code keeps reading one value.
+function gatewayLocationOf(mode) {
+  return normalizeGatewayMode(mode) === 'local-api' ? 'local' : 'remote';
+}
+
+function remoteGatewayModeForKey(apiKey) {
+  return String(apiKey || '').trim() ? 'remote-api' : 'remote-dashboard';
+}
+
+function renderGatewayModeCards() {
+  const location = gatewayLocationOf(els.gatewayModeInput?.value || settings.gatewayMode);
+  for (const card of document.querySelectorAll('[data-gateway-location]')) {
+    const selected = card.dataset.gatewayLocation === location;
+    card.classList.toggle('selected', selected);
+    card.setAttribute('aria-checked', String(selected));
+  }
+}
+
+function applyGatewayMode(mode) {
+  if (!els.gatewayModeInput) return;
+  els.gatewayModeInput.value = normalizeGatewayMode(mode);
+  // Reuse the existing change handler (URL default + help text), then repaint.
+  els.gatewayModeInput.dispatchEvent(new Event('change'));
+  renderGatewayModeCards();
+}
+
 async function checkForUpdates() {
   if (!els.checkUpdatesButton) return;
   els.checkUpdatesButton.disabled = true;
@@ -234,7 +290,7 @@ async function checkForUpdates() {
 }
 
 function updateConnectionPrompt() {
-  const connected = Boolean(settings.apiKey);
+  const connected = isConnected();
   const summary = currentGatewaySummary();
   els.connectPanel.hidden = connected;
   els.connectionPill.textContent = '●';
@@ -243,7 +299,11 @@ function updateConnectionPrompt() {
   els.connectionPill.setAttribute('aria-label', connected ? 'Hermes connected' : 'Hermes not connected');
   if (!connected) {
     els.sendButton.textContent = 'Connect first';
-    setStatus('warn', 'Connect Hermes', `${summary.title}. Click Connect to Hermes or use Manual setup.`);
+    if (isRemoteWsMode()) {
+      setStatus('warn', 'Set a remote dashboard', 'Enter your dashboard https URL in Settings and sign in to it in a browser tab.');
+    } else {
+      setStatus('warn', 'Connect Hermes', `${summary.title}. Click Connect to Hermes or use Manual setup.`);
+    }
   } else {
     els.sendButton.textContent = sending ? 'Queue message' : 'Ask Hermes';
   }
@@ -251,10 +311,11 @@ function updateConnectionPrompt() {
 }
 
 function updateComposerBusyState() {
+  const connected = isConnected();
   if (els.inlineSendButton) {
     els.inlineSendButton.hidden = sending;
-    els.inlineSendButton.disabled = sending || !settings.apiKey;
-    els.inlineSendButton.title = settings.apiKey ? 'Send message' : 'Connect to Hermes first';
+    els.inlineSendButton.disabled = sending || !connected;
+    els.inlineSendButton.title = connected ? 'Send message' : 'Connect to Hermes first';
     els.inlineSendButton.setAttribute('aria-label', els.inlineSendButton.title);
   }
   if (els.stopButton) {
@@ -262,8 +323,8 @@ function updateComposerBusyState() {
     els.stopButton.disabled = !sending;
   }
   if (els.sendButton) {
-    els.sendButton.disabled = !settings.apiKey && !sending;
-    if (settings.apiKey) els.sendButton.textContent = sending ? 'Queue message' : 'Ask Hermes';
+    els.sendButton.disabled = !connected && !sending;
+    if (connected) els.sendButton.textContent = sending ? 'Queue message' : 'Ask Hermes';
   }
   renderQueueNotice();
 }
@@ -300,7 +361,7 @@ function isAbortError(error) {
 async function stopCurrentTurn() {
   if (!sending) return;
   setStatus('warn', 'Stopping Hermes', activeRunId ? `Interrupt requested for ${activeRunId}` : 'Closing the active browser stream');
-  if (activeRunId) {
+  if (activeRunId && !isRemoteWsMode()) {
     apiFetch(`/v1/runs/${encodeURIComponent(activeRunId)}/stop`, { method: 'POST' }).catch(() => {});
   }
   activeAbortController?.abort();
@@ -1397,6 +1458,16 @@ function applySelectedModel(selectedId, { persist = true, keepOpen = false } = {
 async function loadModels({ quiet = false, payload = null } = {}) {
   try {
     let data = payload;
+    if (!data && isRemoteWsMode()) {
+      // Remote reads go over the WS (REST is CORS-blocked). Only possible once
+      // a socket is open; otherwise keep the default model until connected.
+      if (remoteWsConnection?.client?.readyState !== 1) {
+        availableModels = normalizeHermesModels([], settings.model);
+        renderModelOptions(availableModels);
+        return;
+      }
+      data = await remoteWsConnection.client.request(WS_METHODS.modelOptions);
+    }
     if (!data) {
       const response = await apiFetch('/v1/models', { method: 'GET' });
       data = await readJsonResponse(response);
@@ -1630,6 +1701,27 @@ async function loadAllHermesSessions() {
 }
 
 async function loadSessions({ quiet = false } = {}) {
+  if (isRemoteWsMode()) {
+    // Remote reads go over the WS; only possible once a socket is open.
+    if (remoteWsConnection?.client?.readyState !== 1) {
+      availableSessions = [];
+      updateSessionLabel();
+      renderSessionMenu();
+      return;
+    }
+    try {
+      const result = await remoteWsConnection.client.request(WS_METHODS.sessionList, { limit: 200 });
+      availableSessions = normalizeHermesSessions(result);
+      updateSessionLabel();
+      renderSessionMenu();
+      if (!quiet) setStatus('ok', 'Hermes sessions synced', `${availableSessions.length} sessions available`);
+    } catch (error) {
+      updateSessionLabel();
+      renderSessionMenu();
+      if (!quiet) setStatus('warn', 'Session sync failed', error?.message || String(error));
+    }
+    return;
+  }
   if (!settings.apiKey) {
     availableSessions = [];
     updateSessionLabel();
@@ -1666,6 +1758,28 @@ function makeBrowserSessionTitle(date = new Date()) {
 }
 
 async function createHermesBrowserSession({ title = makeBrowserSessionTitle(), focus = true } = {}) {
+  if (isRemoteWsMode()) {
+    const connection = await ensureRemoteWsClient();
+    const result = await connection.client.request(WS_METHODS.sessionCreate, {
+      title,
+      reasoning_effort: normalizeReasoningEffort(settings.reasoningEffort),
+      fast: Boolean(settings.fastMode),
+    });
+    const id = result?.session_id;
+    if (!id) throw new Error('Dashboard did not return a session id.');
+    connection.wsSessionId = id;
+    const session = normalizeHermesSessions({ sessions: [{ id, title, source: settings.sessionSource || DEFAULT_SETTINGS.sessionSource }] })[0]
+      || { id, title, source: settings.sessionSource };
+    availableSessions = normalizeHermesSessions({ sessions: [session, ...availableSessions.filter((item) => item.id !== id)] });
+    settings = { ...settings, sessionId: id, sessionTitle: session.title || title };
+    messages = [];
+    await chrome.storage.local.set({ hermesBrowserSettings: settings, hermesBrowserMessages: [] });
+    renderMessagesFromStorage();
+    updateSessionLabel();
+    renderSessionMenu();
+    if (focus) els.input.focus();
+    return session;
+  }
   const sessionId = makeBrowserSessionId();
   const response = await apiFetch('/api/sessions', {
     method: 'POST',
@@ -1693,10 +1807,20 @@ async function createHermesBrowserSession({ title = makeBrowserSessionTitle(), f
 }
 
 async function openHermesSession(session) {
-  settings = { ...settings, sessionId: session.id, sessionTitle: session.title || session.id };
-  sessionRoutesAvailable = true;
   els.sessionMenu.hidden = true;
   els.sessionMenuButton.setAttribute('aria-expanded', 'false');
+  if (isRemoteWsMode()) {
+    try {
+      const connection = await ensureRemoteWsClient();
+      await connection.client.request(WS_METHODS.sessionResume, { session_id: session.id });
+      connection.wsSessionId = session.id;
+    } catch (error) {
+      setStatus('error', 'Could not open session', error?.message || String(error));
+      return;
+    }
+  }
+  settings = { ...settings, sessionId: session.id, sessionTitle: session.title || session.id };
+  sessionRoutesAvailable = true;
   await chrome.storage.local.set({ hermesBrowserSettings: settings });
   updateSessionLabel();
   renderSessionMenu();
@@ -1705,6 +1829,23 @@ async function openHermesSession(session) {
 }
 
 async function loadSessionMessages(sessionId = settings.sessionId) {
+  if (isRemoteWsMode()) {
+    if (remoteWsConnection?.client?.readyState !== 1) return;
+    try {
+      const result = await remoteWsConnection.client.request(WS_METHODS.sessionHistory, { session_id: sessionId });
+      const rows = Array.isArray(result?.messages) ? result.messages : [];
+      messages = rows
+        .filter((message) => ['user', 'assistant', 'system'].includes(message.role))
+        .map((message) => ({ role: message.role, content: coerceWsMessageContent(message.content), ts: Number(message.timestamp || message.ts || Date.now()) }))
+        .filter((message) => message.content)
+        .slice(-settings.maxLocalMessages);
+      await chrome.storage.local.set({ hermesBrowserMessages: messages });
+      renderMessagesFromStorage();
+    } catch (error) {
+      addMessage('system', `Could not load session messages: ${error?.message || String(error)}`);
+    }
+    return;
+  }
   if (!settings.apiKey) return;
   try {
     const response = await apiFetch(`/api/sessions/${encodeSessionId(sessionId)}/messages`, { method: 'GET' });
@@ -1855,6 +1996,7 @@ function syncSettingsForm() {
   if (els.gatewayModeInput) els.gatewayModeInput.value = settings.gatewayMode || DEFAULT_SETTINGS.gatewayMode;
   els.gatewayUrlInput.value = settings.gatewayUrl;
   renderGatewayHelp();
+  renderGatewayModeCards();
   els.apiKeyInput.value = settings.apiKey || '';
   els.sessionIdInput.value = settings.sessionId;
   els.sessionTitleInput.value = settings.sessionTitle;
@@ -1867,11 +2009,20 @@ function syncSettingsForm() {
 
 async function saveSettingsFromForm() {
   const selected = availableModels.find((model) => model.id === settings.model);
+  const apiKey = els.apiKeyInput.value.trim();
+  // The UI only picks Local vs Remote; for Remote the transport is inferred
+  // from the key (present = API server, blank = dashboard WebSocket).
+  const remote = gatewayLocationOf(els.gatewayModeInput?.value || settings.gatewayMode) === 'remote';
+  const gatewayMode = remote ? remoteGatewayModeForKey(apiKey) : 'local-api';
+  const rawGatewayUrl = els.gatewayUrlInput.value.trim();
+  // In remote mode, don't coerce an empty field to the loopback default — that
+  // would persist a misleading remote+localhost config. Leave it empty.
+  const gatewayUrl = rawGatewayUrl ? normalizeGatewayUrl(rawGatewayUrl) : (remote ? '' : normalizeGatewayUrl(''));
   settings = {
     ...settings,
-    gatewayMode: normalizeGatewayMode(els.gatewayModeInput?.value || settings.gatewayMode),
-    gatewayUrl: normalizeGatewayUrl(els.gatewayUrlInput.value),
-    apiKey: els.apiKeyInput.value.trim(),
+    gatewayMode,
+    gatewayUrl,
+    apiKey,
     model: settings.model || DEFAULT_SETTINGS.model,
     modelContextTokens: selected?.contextTokens || settings.modelContextTokens || 0,
     sessionId: els.sessionIdInput.value.trim() || DEFAULT_SETTINGS.sessionId,
@@ -2280,7 +2431,135 @@ function currentModelOptionsPayload() {
   return buildHermesModelOptions(settings);
 }
 
+async function ensureRemoteWsClient() {
+  const baseUrl = normalizeGatewayUrl(settings.gatewayUrl);
+  if (!isUsableRemoteGatewayUrl(baseUrl)) {
+    throw new Error('Set a remote https gateway URL in Settings before connecting.');
+  }
+  if (remoteWsConnection?.client && remoteWsConnection.client.readyState === 1 && remoteWsConnection.baseUrl === baseUrl) {
+    return remoteWsConnection;
+  }
+  try {
+    remoteWsConnection?.client?.close();
+  } catch {
+    /* ignore */
+  }
+  remoteWsConnection = null;
+
+  console.info('[Hermes] remote: minting ws-ticket via dashboard tab for', baseUrl);
+  const ticket = await mintWsTicket({ tabsApi: chrome.tabs, scriptingApi: chrome.scripting, baseUrl });
+  if (!ticket.ok) {
+    console.warn('[Hermes] remote: ws-ticket mint failed:', ticket.reason, ticket);
+    const error = new Error(ticketFailureHelp(ticket.reason, ticket.origin));
+    error.ticketReason = ticket.reason;
+    throw error;
+  }
+  const wsUrl = buildDashboardWsUrl(baseUrl, ticket.ticket);
+  console.info(
+    `[Hermes] remote: ticket ok (ttl=${ticket.ttlSeconds}s, ${String(ticket.ticket || '').length} chars); connecting`,
+    wsUrl.replace(/ticket=[^&]+/, `ticket=<${String(ticket.ticket || '').length} chars>`),
+  );
+  const client = createGatewayClient();
+  try {
+    await client.connect(wsUrl);
+  } catch (error) {
+    console.warn('[Hermes] remote: WebSocket connect failed:', error?.message || error);
+    throw error;
+  }
+  const connection = { client, baseUrl, wsSessionId: '' };
+  client.on('close', () => {
+    if (remoteWsConnection === connection) remoteWsConnection = null;
+  });
+  remoteWsConnection = connection;
+  return connection;
+}
+
+async function ensureRemoteWsSession(connection) {
+  if (connection.wsSessionId) return connection.wsSessionId;
+  const result = await connection.client.request(WS_METHODS.sessionCreate, {
+    title: settings.sessionTitle,
+    reasoning_effort: normalizeReasoningEffort(settings.reasoningEffort),
+    fast: Boolean(settings.fastMode),
+  });
+  connection.wsSessionId = result?.session_id || '';
+  if (!connection.wsSessionId) throw new Error('Dashboard did not return a session id.');
+  // Reflect the dashboard-assigned id so the session menu/label track the live
+  // remote session instead of the local default placeholder.
+  settings = { ...settings, sessionId: connection.wsSessionId };
+  await chrome.storage.local.set({ hermesBrowserSettings: settings });
+  updateSessionLabel();
+  return connection.wsSessionId;
+}
+
+// Dashboard history content may be a string, an array of text parts, or a
+// single block object; flatten to plain text for the message pane.
+function coerceWsMessageContent(content) {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map((part) => (typeof part === 'string' ? part : part?.text || '')).filter(Boolean).join('');
+  }
+  if (content && typeof content === 'object') return String(content.text || '');
+  return '';
+}
+
+async function streamRemoteWsChat(prompt, onDelta, onTool, { signal, onRun } = {}) {
+  const connection = await ensureRemoteWsClient();
+  const sessionId = await ensureRemoteWsSession(connection);
+  onRun?.(sessionId);
+  const { client } = connection;
+
+  return new Promise((resolve, reject) => {
+    let finalText = '';
+    let settled = false;
+    const offs = [];
+    const forThisSession = (event) => !event.sessionId || event.sessionId === sessionId;
+
+    const cleanup = () => {
+      for (const off of offs) off();
+      signal?.removeEventListener?.('abort', onAbort);
+    };
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn(value);
+    };
+    function onAbort() {
+      client.request(WS_METHODS.sessionInterrupt, { session_id: sessionId }).catch(() => {});
+      finish(reject, new DOMException('Hermes turn stopped by user', 'AbortError'));
+    }
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener?.('abort', onAbort, { once: true });
+
+    offs.push(client.on(WS_EVENTS.messageDelta, (event) => {
+      if (!forThisSession(event)) return;
+      finalText += event.payload?.text || '';
+      onDelta(finalText);
+    }));
+    offs.push(client.on(WS_EVENTS.messageComplete, (event) => {
+      if (!forThisSession(event)) return;
+      finalText = event.payload?.text || finalText;
+      onDelta(finalText);
+      finish(resolve, finalText);
+    }));
+    offs.push(client.on('tool.start', (event) => {
+      if (forThisSession(event) && onTool) onTool({ tool_name: event.payload?.name });
+    }));
+    offs.push(client.on(WS_EVENTS.error, (event) => {
+      finish(reject, new Error(event.payload?.message || 'Dashboard stream error'));
+    }));
+    offs.push(client.on('close', () => finish(reject, new Error('Dashboard connection closed mid-turn.'))));
+
+    client.request(WS_METHODS.promptSubmit, { session_id: sessionId, text: prompt }).catch((error) => finish(reject, error));
+  });
+}
+
 async function streamSessionChat(prompt, onDelta, onTool, { signal, attachments: turnAttachments = attachments, onRun } = {}) {
+  if (isRemoteWsMode()) return streamRemoteWsChat(prompt, onDelta, onTool, { signal, onRun });
   const hasSessionRoutes = await ensureHermesSession();
   if (!hasSessionRoutes) return streamChatCompletions(prompt, onDelta, onTool, { signal, attachments: turnAttachments, onRun });
 
@@ -2463,9 +2742,11 @@ async function fallbackChatCompletions(prompt, turnAttachments = attachments) {
 }
 
 async function askHermes(userText, turnAttachments = [...attachments]) {
-  if (!settings.apiKey) {
+  if (!isConnected()) {
     updateConnectionPrompt();
-    addMessage('system', 'Connection setup needed: click Connect to Hermes, approve in the local Hermes approval page, then send again. Your draft is still in the composer.');
+    addMessage('system', isRemoteWsMode()
+      ? 'Remote setup needed: enter your dashboard https URL in Settings and sign in to that dashboard in a browser tab. Your draft is still in the composer.'
+      : 'Connection setup needed: click Connect to Hermes, approve in the local Hermes approval page, then send again. Your draft is still in the composer.');
     els.connectButton.focus();
     return false;
   }
@@ -2521,6 +2802,11 @@ async function askHermes(userText, turnAttachments = [...attachments]) {
     } catch (streamError) {
       if (isAbortError(streamError)) {
         answer = liveText ? `${liveText}\n\n[stopped by user]` : '[stopped by user]';
+      } else if (isRemoteWsMode()) {
+        // No REST fallback in remote-dashboard mode — the api_server surface is
+        // not reachable cross-origin. Surface the WS/ticket error directly.
+        streamView.update(`Could not reach the Hermes dashboard.\n${streamError.message}`);
+        throw streamError;
       } else {
         streamView.update(`Streaming failed, retrying non-streaming...\n${streamError.message}`);
         answer = await fallbackSessionChat(prompt, preparedAttachments);
@@ -2552,11 +2838,48 @@ async function askHermes(userText, turnAttachments = [...attachments]) {
   return didSend;
 }
 
+let testConnectionFlashTimer = null;
+
+function flashTestConnectionResult(ok) {
+  const button = els.testConnectionButton;
+  if (!button) return;
+  clearTimeout(testConnectionFlashTimer);
+  button.classList.remove('success', 'error');
+  button.classList.add(ok ? 'success' : 'error');
+  button.textContent = ok ? 'Connected ✓' : 'Failed';
+  testConnectionFlashTimer = setTimeout(() => {
+    button.classList.remove('success', 'error');
+    button.textContent = 'Test connection';
+  }, 2600);
+}
+
 async function testConnection() {
   await saveSettingsFromForm();
   els.testConnectionButton.disabled = true;
   els.testConnectionButton.textContent = 'Testing...';
+  els.testConnectionButton.classList.remove('success', 'error');
+  clearTimeout(testConnectionFlashTimer);
+  let ok = false;
   try {
+    if (isRemoteWsMode()) {
+      // The dashboard's REST surface (including /api/status) is CORS-blocked
+      // from the extension origin, so the WebSocket is the only thing we can
+      // exercise. Minting a ticket + opening the socket validates the whole
+      // path: a signed-in dashboard tab, the ticket flow, and the handshake.
+      const connection = await ensureRemoteWsClient();
+      let modelNote = '';
+      try {
+        const models = await connection.client.request(WS_METHODS.modelOptions);
+        await loadModels({ quiet: true, payload: models });
+        modelNote = availableModels.length ? ` · ${availableModels.length} models` : '';
+      } catch {
+        // model.options shape varies across gateways; the socket is already proven.
+      }
+      updateConnectionPrompt();
+      setStatus('ok', 'Remote Hermes dashboard connected', `${normalizeGatewayUrl(settings.gatewayUrl)}${modelNote}`);
+      ok = true;
+      return;
+    }
     const response = await apiFetch('/health', { method: 'GET' });
     const text = await response.text();
     if (!response.ok) throw new Error(`${response.status}: ${text}`);
@@ -2574,11 +2897,12 @@ async function testConnection() {
       hasSessionRoutes ? 'Hermes gateway + session API connected' : 'Hermes gateway connected',
       hasSessionRoutes ? normalizeGatewayUrl(settings.gatewayUrl) : `${normalizeGatewayUrl(settings.gatewayUrl)} - OpenAI-compatible fallback mode`,
     );
+    ok = true;
   } catch (error) {
     setStatus('error', 'Hermes gateway test failed', error?.message || String(error));
   } finally {
     els.testConnectionButton.disabled = false;
-    els.testConnectionButton.textContent = 'Test connection';
+    flashTestConnectionResult(ok);
   }
 }
 
@@ -2620,7 +2944,7 @@ function bindEvents() {
     }
   });
   els.newSessionButton.addEventListener('click', async () => {
-    if (!settings.apiKey) {
+    if (!isConnected()) {
       updateConnectionPrompt();
       els.connectButton.focus();
       return;
@@ -2775,6 +3099,19 @@ function bindEvents() {
     renderGatewayHelp();
   });
   els.gatewayUrlInput?.addEventListener('input', renderGatewayHelp);
+  for (const card of document.querySelectorAll('[data-gateway-location]')) {
+    card.addEventListener('click', () => {
+      const local = card.dataset.gatewayLocation === 'local';
+      applyGatewayMode(local ? 'local-api' : remoteGatewayModeForKey(els.apiKeyInput?.value));
+    });
+  }
+  // In remote mode the key field decides the transport: a key means a remote
+  // API server, blank means the dashboard WebSocket. Re-derive as the user types.
+  els.apiKeyInput?.addEventListener('input', () => {
+    if (gatewayLocationOf(els.gatewayModeInput?.value) === 'remote') {
+      applyGatewayMode(remoteGatewayModeForKey(els.apiKeyInput.value));
+    }
+  });
   for (const button of els.colorModeButtons || []) {
     button.addEventListener('click', () => setAppearanceOption('colorMode', button.dataset.colorMode));
   }

--- a/manifest.json
+++ b/manifest.json
@@ -56,6 +56,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; connect-src http: https:;"
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src http: https: wss:;"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "test": "node --test tests/*.test.mjs",
-    "check:js": "node --check extension/sidepanel.js && node --check extension/background.js && node --check extension/content.js && node --check extension/lib/common.mjs && node --check scripts/windows-setup.mjs && node --check scripts/hermes-review-github-event.mjs && node --check scripts/hermes-review-watch.mjs",
+    "check:js": "node --check extension/sidepanel.js && node --check extension/background.js && node --check extension/content.js && node --check extension/lib/common.mjs && node --check extension/lib/gateway-ws.mjs && node --check extension/lib/dashboard-bridge.mjs && node --check scripts/windows-setup.mjs && node --check scripts/hermes-review-github-event.mjs && node --check scripts/hermes-review-watch.mjs",
     "check:manifest": "node scripts/check-manifest.mjs",
     "verify": "npm run test && npm run check:js && npm run check:manifest",
     "build": "node scripts/build.mjs",

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -17,6 +17,7 @@ import {
   extractAssistantText,
   formatContextMeter,
   gatewayConnectionSummary,
+  isUsableRemoteGatewayUrl,
   formatYoutubeTranscript,
   groupModelsForMenu,
   groupSessionsForMenu,
@@ -116,7 +117,7 @@ test('isRestrictedUrl blocks browser internals and sensitive account categories'
 });
 
 test('gateway settings support explicit local and remote Hermes API servers', () => {
-  assert.deepEqual(GATEWAY_MODES.map((mode) => mode.value), ['local-api', 'remote-api']);
+  assert.deepEqual(GATEWAY_MODES.map((mode) => mode.value), ['local-api', 'remote-api', 'remote-dashboard']);
   assert.equal(DEFAULT_SETTINGS.gatewayMode, 'local-api');
 
   const remote = gatewayConnectionSummary({
@@ -127,13 +128,26 @@ test('gateway settings support explicit local and remote Hermes API servers', ()
   assert.equal(remote.mode.value, 'remote-api');
   assert.equal(remote.normalizedUrl, 'https://agent.example.com/hermes');
   assert.match(remote.title, /Remote Hermes API server/);
-  assert.match(remote.setupHint, /API_SERVER_HOST=0\.0\.0\.0/);
   assert.match(remote.setupHint, /API_SERVER_CORS_ORIGINS=chrome-extension:\/\/abc123/);
   assert.match(remote.setupHint, /API_SERVER_KEY/);
 
   const local = gatewayConnectionSummary({ gatewayMode: 'nonsense', gatewayUrl: '' });
   assert.equal(local.mode.value, 'local-api');
   assert.equal(local.normalizedUrl, 'http://127.0.0.1:8642');
+
+  const dashboard = gatewayConnectionSummary({ gatewayMode: 'remote-dashboard', gatewayUrl: 'https://host.ts.net' });
+  assert.equal(dashboard.mode.value, 'remote-dashboard');
+  assert.match(dashboard.title, /Remote Hermes dashboard/);
+  assert.match(dashboard.setupHint, /WebSocket/);
+  assert.match(dashboard.setupHint, /sign in/i);
+});
+
+test('isUsableRemoteGatewayUrl requires a parseable https URL', () => {
+  assert.equal(isUsableRemoteGatewayUrl('https://kurokami.example.ts.net'), true);
+  assert.equal(isUsableRemoteGatewayUrl('https://host.ts.net:8643/hermes'), true);
+  assert.equal(isUsableRemoteGatewayUrl('http://host.ts.net'), false); // non-loopback http is mixed-content blocked
+  assert.equal(isUsableRemoteGatewayUrl('example.com'), false); // no scheme, fails to parse
+  assert.equal(isUsableRemoteGatewayUrl(''), false);
 });
 
 test('manifest allows remote Hermes API server connections from extension pages', () => {
@@ -142,6 +156,7 @@ test('manifest allows remote Hermes API server connections from extension pages'
   assert.match(csp, /connect-src/);
   assert.match(csp, /http:/);
   assert.match(csp, /https:/);
+  assert.match(csp, /wss:/); // remote-dashboard mode connects over the dashboard WebSocket
   assert.ok(manifest.host_permissions.includes('http://*/*'));
   assert.ok(manifest.host_permissions.includes('https://*/*'));
 });

--- a/tests/dashboard-bridge.test.mjs
+++ b/tests/dashboard-bridge.test.mjs
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  originOf,
+  wsTicketUrl,
+  mintTicketInPage,
+  findDashboardTab,
+  mintWsTicket,
+  ticketFailureHelp,
+} from '../extension/lib/dashboard-bridge.mjs';
+
+test('originOf and wsTicketUrl normalize the dashboard base', () => {
+  assert.equal(originOf('https://kurokami.example.ts.net/some/path?q=1'), 'https://kurokami.example.ts.net');
+  assert.equal(originOf('not a url'), '');
+  assert.equal(wsTicketUrl('https://host.ts.net/'), 'https://host.ts.net/api/auth/ws-ticket');
+  assert.equal(wsTicketUrl('https://host.ts.net/hermes'), 'https://host.ts.net/hermes/api/auth/ws-ticket');
+  // Query/hash from a pasted address bar URL must not corrupt the ticket path.
+  assert.equal(wsTicketUrl('https://host.ts.net/hermes?x=1#y'), 'https://host.ts.net/hermes/api/auth/ws-ticket');
+});
+
+test('mintTicketInPage maps fetch outcomes to structured results', async () => {
+  const original = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => ({ ticket: 'T1', ttl_seconds: 30 }) });
+    assert.deepEqual(await mintTicketInPage('https://h/api/auth/ws-ticket'), { ok: true, ticket: 'T1', ttlSeconds: 30 });
+
+    globalThis.fetch = async () => ({ ok: false, status: 401, json: async () => ({}) });
+    assert.deepEqual(await mintTicketInPage('https://h/api/auth/ws-ticket'), { ok: false, reason: 'not_signed_in', status: 401 });
+
+    globalThis.fetch = async () => ({ ok: false, status: 500, json: async () => ({}) });
+    assert.equal((await mintTicketInPage('https://h/api/auth/ws-ticket')).reason, 'ticket_http_500');
+
+    globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => ({}) });
+    assert.equal((await mintTicketInPage('https://h/api/auth/ws-ticket')).reason, 'no_ticket_in_response');
+
+    globalThis.fetch = async () => {
+      throw new Error('network down');
+    };
+    const failed = await mintTicketInPage('https://h/api/auth/ws-ticket');
+    assert.equal(failed.reason, 'fetch_failed');
+    assert.match(failed.detail, /network down/);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('findDashboardTab picks a loaded same-origin tab and skips discarded ones', async () => {
+  const tabsApi = {
+    query: async ({ url }) => {
+      assert.equal(url, 'https://host.ts.net/*');
+      return [
+        { id: 1, url: 'https://host.ts.net/login', discarded: true },
+        { id: 2, url: 'https://host.ts.net/dashboard', discarded: false },
+      ];
+    },
+  };
+  const tab = await findDashboardTab(tabsApi, 'https://host.ts.net');
+  assert.equal(tab.id, 2);
+
+  const none = await findDashboardTab({ query: async () => [] }, 'https://host.ts.net');
+  assert.equal(none, null);
+});
+
+test('mintWsTicket returns no_dashboard_tab when no tab is open', async () => {
+  const result = await mintWsTicket({
+    tabsApi: { query: async () => [] },
+    scriptingApi: { executeScript: async () => [{ result: { ok: true } }] },
+    baseUrl: 'https://host.ts.net',
+  });
+  assert.deepEqual(result, { ok: false, reason: 'no_dashboard_tab', origin: 'https://host.ts.net' });
+});
+
+test('mintWsTicket injects the mint into the dashboard tab with the ticket URL', async () => {
+  let injected = null;
+  const result = await mintWsTicket({
+    tabsApi: { query: async () => [{ id: 7, url: 'https://host.ts.net/x', discarded: false }] },
+    scriptingApi: {
+      executeScript: async (opts) => {
+        injected = opts;
+        return [{ result: { ok: true, ticket: 'TKT', ttlSeconds: 30 } }];
+      },
+    },
+    baseUrl: 'https://host.ts.net',
+    mintFn: () => {},
+  });
+  assert.deepEqual(result, { ok: true, ticket: 'TKT', ttlSeconds: 30 });
+  assert.equal(injected.target.tabId, 7);
+  assert.deepEqual(injected.args, ['https://host.ts.net/api/auth/ws-ticket']);
+});
+
+test('ticketFailureHelp gives actionable copy per reason', () => {
+  assert.match(ticketFailureHelp('no_dashboard_tab', 'https://host.ts.net'), /Open https:\/\/host\.ts\.net.*sign in/);
+  assert.match(ticketFailureHelp('not_signed_in'), /not signed in/i);
+});

--- a/tests/gateway-ws.test.mjs
+++ b/tests/gateway-ws.test.mjs
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildDashboardWsUrl,
+  classifyGatewayFrame,
+  createGatewayClient,
+} from '../extension/lib/gateway-ws.mjs';
+
+class FakeWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    this.sent = [];
+    this._listeners = {};
+    FakeWebSocket.last = this;
+  }
+
+  addEventListener(type, fn) {
+    (this._listeners[type] ||= []).push(fn);
+  }
+
+  send(data) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = 3;
+    this._emit('close', { code: 1000 });
+  }
+
+  _emit(type, event) {
+    for (const fn of this._listeners[type] || []) fn(event);
+  }
+
+  _open() {
+    this.readyState = 1;
+    this._emit('open', {});
+  }
+
+  _message(obj) {
+    this._emit('message', { data: typeof obj === 'string' ? obj : JSON.stringify(obj) });
+  }
+}
+
+test('buildDashboardWsUrl upgrades scheme, keeps path prefix, encodes ticket', () => {
+  assert.equal(
+    buildDashboardWsUrl('https://kurokami.example.ts.net', 'abc/123'),
+    'wss://kurokami.example.ts.net/api/ws?ticket=abc%2F123',
+  );
+  assert.equal(
+    buildDashboardWsUrl('http://127.0.0.1:8642/hermes/', 't1'),
+    'ws://127.0.0.1:8642/hermes/api/ws?ticket=t1',
+  );
+});
+
+test('classifyGatewayFrame distinguishes responses, errors, events, and noise', () => {
+  assert.deepEqual(classifyGatewayFrame('{"id":1,"result":{"ok":true}}'), {
+    kind: 'response',
+    id: 1,
+    result: { ok: true },
+  });
+  assert.equal(classifyGatewayFrame('{"id":2,"error":{"message":"nope"}}').kind, 'error');
+  assert.deepEqual(
+    classifyGatewayFrame({ method: 'event', params: { type: 'message.delta', session_id: 's1', payload: { text: 'hi' } } }),
+    { kind: 'event', type: 'message.delta', sessionId: 's1', payload: { text: 'hi' } },
+  );
+  assert.equal(classifyGatewayFrame('not json').kind, 'ignore');
+  assert.equal(classifyGatewayFrame({ method: 'event', params: {} }).kind, 'ignore');
+});
+
+test('gateway client connects, resolves a matching RPC response, and dispatches events', async () => {
+  const client = createGatewayClient({ WebSocketImpl: FakeWebSocket });
+  const connecting = client.connect('wss://host/api/ws?ticket=t');
+  FakeWebSocket.last._open();
+  await connecting;
+
+  const deltas = [];
+  client.on('message.delta', (event) => deltas.push(event.payload.text));
+
+  const pending = client.request('prompt.submit', { session_id: 's1', text: 'hello' });
+  const sent = JSON.parse(FakeWebSocket.last.sent.at(-1));
+  assert.equal(sent.jsonrpc, '2.0');
+  assert.equal(sent.method, 'prompt.submit');
+  assert.deepEqual(sent.params, { session_id: 's1', text: 'hello' });
+
+  FakeWebSocket.last._message({ method: 'event', params: { type: 'message.delta', session_id: 's1', payload: { text: 'hel' } } });
+  FakeWebSocket.last._message({ id: sent.id, result: { status: 'streaming' } });
+
+  assert.deepEqual(await pending, { status: 'streaming' });
+  assert.deepEqual(deltas, ['hel']);
+});
+
+test('gateway client rejects pending requests when the socket closes', async () => {
+  const client = createGatewayClient({ WebSocketImpl: FakeWebSocket });
+  const connecting = client.connect('wss://host/api/ws?ticket=t');
+  FakeWebSocket.last._open();
+  await connecting;
+
+  const pending = client.request('session.list', {});
+  FakeWebSocket.last.close();
+  await assert.rejects(pending, /closed/i);
+});


### PR DESCRIPTION
Adds a **Dashboard (WebSocket)** option for reaching a remote Hermes when the only thing exposed is the OAuth-gated dashboard, with no API server. It talks to the dashboard's `/api/ws` socket and authenticates with a single-use ws-ticket minted from a signed-in dashboard tab, since the extension can't send the dashboard cookie cross-origin. No API key, no API server.

The gateway picker stays just Local/Remote. In Remote the transport is inferred from the API key field: a key uses your `remote-api` path, blank uses the dashboard WebSocket. Same `gatewayMode` underneath. I also fixed the setup-help overflow and trimmed the copy.

Tests included. Image upload and the skills/profiles lists don't work over the dashboard socket (REST-only, CORS-blocked). Totally fine if it's more than you want to carry upstream.

## Screenshot

<img width="360" height="1046" alt="chrome_9jfeRN9HFl" src="https://github.com/user-attachments/assets/8b4c0089-e59a-4f66-8847-d96e163cd9f1" />
