### PR TITLE
fix: support remote agent discovery

### DIFF
--- a/extension/lib/agent-discovery.mjs
+++ b/extension/lib/agent-discovery.mjs
@@ -10,19 +10,24 @@ const PROBE_TIMEOUT_MS = 1500;
 
 export async function probeGatewayHealth(baseUrl, { apiKey = '', timeoutMs = PROBE_TIMEOUT_MS } = {}) {
   if (!baseUrl) return { ok: false, error: 'no-url' };
-  const url = `${normalizeGatewayUrl(baseUrl)}/health`;
+  const normalized = normalizeGatewayUrl(baseUrl);
+  const url = `${normalized}/health`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
     const response = await fetch(url, { headers, signal: controller.signal });
     const body = await response.json().catch(() => ({}));
+    let model = body.model || '';
+    if (response.ok && body.platform === 'hermes-agent' && !model) {
+      model = await probeGatewayModelName(normalized, { headers, signal: controller.signal });
+    }
     return {
       ok: response.ok,
       status: response.status,
       version: body.version || '',
       platform: body.platform || '',
-      model: body.model || '',
+      model,
     };
   } catch (error) {
     return { ok: false, error: error?.name === 'AbortError' ? 'timeout' : (error?.message || 'error') };
@@ -31,12 +36,22 @@ export async function probeGatewayHealth(baseUrl, { apiKey = '', timeoutMs = PRO
   }
 }
 
+async function probeGatewayModelName(baseUrl, { headers = {}, signal } = {}) {
+  try {
+    const response = await fetch(`${baseUrl}/v1/models`, { headers, signal });
+    if (!response.ok) return '';
+    const payload = await response.json().catch(() => ({}));
+    const first = Array.isArray(payload?.data) ? payload.data[0] : null;
+    return String(first?.id || '').trim();
+  } catch (_error) {
+    return '';
+  }
+}
+
 export function deriveAgentName(port, probe) {
   if (!probe || !probe.ok) return null;
   if (probe.platform !== 'hermes-agent') return null;
-  // Future: gateway could expose its profile name in /health/detailed.
-  // For now, port-derived name is the only reliable label.
-  return `agent-${port}`;
+  return probe.model || `agent-${port}`;
 }
 
 export async function discoverLocalAgents({

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -46,6 +46,8 @@ export const DEFAULT_SETTINGS = Object.freeze({
   includePageText: true,
   includeSelectedText: true,
   transcriptProvider: 'default',
+  agentDiscoveryHost: '127.0.0.1',
+  agentDiscoveryScheme: 'http',
   colorMode: 'dark',
   appearanceTheme: 'nous',
   maxTabs: 12,

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -206,14 +206,24 @@
           <section class="settings-section">
             <h3>Connected agent</h3>
             <p class="hint">
-              Scans localhost for running Hermes API gateways. Each agent can run
-              as a separate gateway process on its own port. Use this to switch
-              between trusted local agents that share the same browser token.
+              Scans a trusted Hermes API host for running gateways. Use localhost for
+              same-machine agents, or a Tailscale host/IP for private remote agents.
             </p>
             <div id="agentList" class="agent-list" role="list" aria-label="Discovered Hermes agents"></div>
             <div class="settings-row">
-              <button id="refreshAgentsButton" class="secondary" type="button">↻ Scan local agents</button>
+              <button id="refreshAgentsButton" class="secondary" type="button">↻ Scan agents</button>
             </div>
+            <label>
+              Agent host
+              <input id="agentHostInput" type="text" autocomplete="off" placeholder="127.0.0.1 or macbook.tailnet.ts.net" />
+            </label>
+            <label>
+              Agent scheme
+              <select id="agentSchemeInput">
+                <option value="http">http</option>
+                <option value="https">https</option>
+              </select>
+            </label>
             <label>
               Agent ports (comma-separated, default 8642-8646)
               <input id="agentPortsInput" type="text" inputmode="numeric" placeholder="8642,8643,8644,8645,8646" />

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -141,6 +141,8 @@ const els = {
   agentList: $('#agentList'),
   refreshAgentsButton: $('#refreshAgentsButton'),
   addCustomAgentButton: $('#addCustomAgentButton'),
+  agentHostInput: $('#agentHostInput'),
+  agentSchemeInput: $('#agentSchemeInput'),
   agentPortsInput: $('#agentPortsInput'),
   agentPickerStatus: $('#agentPickerStatus'),
   themeGrid: $('#themeGrid'),
@@ -1706,9 +1708,29 @@ function getAgentPorts() {
   return [...DEFAULT_AGENT_PORTS];
 }
 
-async function persistAgentPorts(ports) {
-  settings = { ...settings, agentPorts: ports };
+function normalizeAgentDiscoveryHost(value = '') {
+  return String(value || DEFAULT_SETTINGS.agentDiscoveryHost)
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/+$/, '') || DEFAULT_SETTINGS.agentDiscoveryHost;
+}
+
+function normalizeAgentDiscoveryScheme(value = '') {
+  return String(value || DEFAULT_SETTINGS.agentDiscoveryScheme).trim().toLowerCase() === 'https' ? 'https' : 'http';
+}
+
+async function persistAgentDiscoverySettings({ ports = getAgentPorts(), host = settings.agentDiscoveryHost, scheme = settings.agentDiscoveryScheme } = {}) {
+  settings = {
+    ...settings,
+    agentPorts: ports,
+    agentDiscoveryHost: normalizeAgentDiscoveryHost(host),
+    agentDiscoveryScheme: normalizeAgentDiscoveryScheme(scheme),
+  };
   await chrome.storage.local.set({ hermesBrowserSettings: settings });
+}
+
+async function persistAgentPorts(ports) {
+  await persistAgentDiscoverySettings({ ports });
 }
 
 function renderAgentList(agents = discoveredAgents) {
@@ -1765,14 +1787,16 @@ async function loadAgents({ quiet = false } = {}) {
     els.agentList.innerHTML = '<p class="hint">No agent ports configured. Add a custom URL or set ports in the field below.</p>';
     return;
   }
-  if (els.agentPickerStatus) els.agentPickerStatus.textContent = `Scanning ${ports.length} port${ports.length === 1 ? '' : 's'}...`;
+  if (els.agentPickerStatus) els.agentPickerStatus.textContent = `Scanning ${ports.length} port${ports.length === 1 ? '' : 's'} on ${normalizeAgentDiscoveryHost(settings.agentDiscoveryHost)}...`;
   const key = settings.apiKey || '';
-  discoveredAgents = await discoverLocalAgents({ ports, apiKey: key });
+  const host = normalizeAgentDiscoveryHost(settings.agentDiscoveryHost);
+  const scheme = normalizeAgentDiscoveryScheme(settings.agentDiscoveryScheme);
+  discoveredAgents = await discoverLocalAgents({ ports, apiKey: key, host, scheme });
   const healthy = activeAgents(discoveredAgents);
   renderAgentList(discoveredAgents);
   if (els.agentPickerStatus) {
     if (healthy.length === 0) {
-      els.agentPickerStatus.textContent = `Scanned ${ports.length} ports — no Hermes agents online.`;
+      els.agentPickerStatus.textContent = `Scanned ${ports.length} ports on ${host} — no Hermes agents online.`;
     } else if (healthy.length === 1) {
       els.agentPickerStatus.textContent = `1 agent online at port ${healthy[0].port}.`;
     } else {
@@ -2202,6 +2226,9 @@ function syncSettingsForm() {
   els.includePageTextInput.checked = Boolean(settings.includePageText);
   els.includeSelectedTextInput.checked = Boolean(settings.includeSelectedText);
   els.transcriptProviderInput.value = settings.transcriptProvider || DEFAULT_SETTINGS.transcriptProvider;
+  if (els.agentHostInput) els.agentHostInput.value = normalizeAgentDiscoveryHost(settings.agentDiscoveryHost);
+  if (els.agentSchemeInput) els.agentSchemeInput.value = normalizeAgentDiscoveryScheme(settings.agentDiscoveryScheme);
+  if (els.agentPortsInput) els.agentPortsInput.value = getAgentPorts().join(',');
 }
 
 async function saveSettingsFromForm() {
@@ -2230,6 +2257,9 @@ async function saveSettingsFromForm() {
     includePageText: els.includePageTextInput.checked,
     includeSelectedText: els.includeSelectedTextInput.checked,
     transcriptProvider: els.transcriptProviderInput.value.trim() || DEFAULT_SETTINGS.transcriptProvider,
+    agentDiscoveryHost: normalizeAgentDiscoveryHost(els.agentHostInput?.value || settings.agentDiscoveryHost),
+    agentDiscoveryScheme: normalizeAgentDiscoveryScheme(els.agentSchemeInput?.value || settings.agentDiscoveryScheme),
+    agentPorts: parseAgentPortsInput(els.agentPortsInput?.value || '').length ? parseAgentPortsInput(els.agentPortsInput?.value || '') : getAgentPorts(),
     colorMode: normalizeColorMode(settings.colorMode),
     appearanceTheme: normalizeAppearanceTheme(settings.appearanceTheme),
   };
@@ -3234,12 +3264,22 @@ function bindEvents() {
       setStatus('warn', 'No agent ports', 'Enter at least one port number, e.g. 8642,8643,8644,8645,8646');
       return;
     }
-    persistAgentPorts(ports);
+    persistAgentDiscoverySettings({
+      ports,
+      host: els.agentHostInput?.value || settings.agentDiscoveryHost,
+      scheme: els.agentSchemeInput?.value || settings.agentDiscoveryScheme,
+    });
     loadAgents();
+  });
+  els.agentHostInput?.addEventListener('change', () => {
+    persistAgentDiscoverySettings({ host: els.agentHostInput.value });
+  });
+  els.agentSchemeInput?.addEventListener('change', () => {
+    persistAgentDiscoverySettings({ scheme: els.agentSchemeInput.value });
   });
   els.agentPortsInput?.addEventListener('change', () => {
     const ports = parseAgentPortsInput(els.agentPortsInput.value);
-    if (ports.length) persistAgentPorts(ports);
+    if (ports.length) persistAgentDiscoverySettings({ ports });
   });
   els.editModelsButton.addEventListener('click', () => {
     closeFloatingPanels();

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -667,17 +667,22 @@ test('discoverLocalAgents scans the configured port range and labels healthy age
   const { discoverLocalAgents, activeAgents } = await import('../extension/lib/agent-discovery.mjs');
   const originalFetch = globalThis.fetch;
   try {
+    const fetchCalls = [];
     globalThis.fetch = async (url) => {
+      fetchCalls.push(url);
+      if (url.includes(':8642') && url.endsWith('/v1/models')) return { ok: true, json: async () => ({ data: [{ id: 'alfred' }] }) };
+      if (url.includes(':8643') && url.endsWith('/v1/models')) return { ok: true, json: async () => ({ data: [{ id: 'eva' }] }) };
       if (url.includes(':8642')) return { ok: true, json: async () => ({ version: '0.17.0', platform: 'hermes-agent' }) };
       if (url.includes(':8643')) return { ok: true, json: async () => ({ version: '0.17.0', platform: 'hermes-agent' }) };
       if (url.includes(':8644')) return { ok: false, json: async () => ({}) };
       return { ok: false, json: async () => ({}) };
     };
-    const agents = await discoverLocalAgents({ ports: [8642, 8643, 8644, 8645, 8646] });
+    const agents = await discoverLocalAgents({ ports: [8642, 8643, 8644, 8645, 8646], host: 'macbook.tailnet.ts.net', scheme: 'https' });
+    assert.equal(fetchCalls[0], 'https://macbook.tailnet.ts.net:8642/health');
     assert.equal(agents.length, 5);
     assert.equal(agents[0].ok, true);
     assert.equal(agents[0].port, 8642);
-    assert.equal(agents[0].name, 'agent-8642');
+    assert.equal(agents[0].name, 'alfred');
     assert.equal(agents[2].ok, false);
     assert.equal(agents[2].name, null);
     const healthy = activeAgents(agents);


### PR DESCRIPTION
## Summary
- let the Connected agent scanner target a trusted remote host, including private Tailscale hostnames/IPs
- persist agent discovery host/scheme/ports in extension settings
- label discovered agents from `/v1/models` when `/health` does not expose a profile/model name, falling back to `agent-<port>`

## Why
The extension already supports remote Gateway URLs, but the Connected agent picker was still localhost-only and only produced port-derived labels. Multi-machine Hermes setups commonly run separate API servers on trusted private networks/Tailscale, e.g. a laptop extension switching between local and Mac-hosted agents. This makes those agents discoverable and recognizable without changing the manual Gateway URL flow.

## Tests
- `npm test`
- `npm run build`
- `git diff --check`
