### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check JavaScript syntax
+        run: npm run check:js
+
+      - name: Verify manifest
+        run: npm run check:manifest
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Verify build artifact
+        run: |
+          test -d dist && \
+          test -f dist/manifest.json && \
+          echo "Build verified: dist/manifest.json exists"
+
+  package:
+    needs: verify
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build and package
+        run: npm run package
+
+      - name: Upload packaged artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-browser-extension
+          path: artifacts/
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Thanks for helping improve Hermes Browser Extension.
 
 - Use Node.js 20+.
 - Run `npm run verify` before opening a PR.
+- The CI runs `verify` + `build` on every push and pull request. You can see results
+  at the bottom of your PR before a maintainer reviews it.
 - Keep v0.1 read-only unless a proposal explicitly changes the permission model.
 - Load `dist/` unpacked for manual browser testing; do not load the repo root.
 


### PR DESCRIPTION
## Summary

Add a GitHub Actions CI pipeline that runs tests, syntax checks, manifest validation, and build on every push/PR to `main`. Includes a `package` job on main-branch pushes that produce a packaged release artifact.

## Changes

**`.github/workflows/ci.yml`** — two job CI pipeline:

| Job | Trigger | Steps |
|-----|---------|-------|
| `verify` | push + PR to `main` (Node 20 + 22 matrix) | `npm ci` → `npm test` → `check:js` → `check:manifest` → `npm run build` → verify `dist/manifest.json` |
| `package` | push to `main` only (Node 22) | `npm ci` → `npm run package` → upload `artifacts/` |

**`CONTRIBUTING.md`** — mention CI status on PRs.

## Context

Currently there is no CI — changes are verified manually. This workflow mirrors the existing `verify` script (`npm run test && npm run check:js && npm run check:manifest`) and the build step, so contributors verify the same things the CI checks.