### PR TITLE
style: add ESLint and Prettier configuration

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Thanks for helping improve Hermes Browser Extension.
 
 - Use Node.js 20+.
 - Run `npm run verify` before opening a PR.
+- Run `npm run lint` and `npm run format:check` to catch style and syntax issues
+  early. Use `npm run format` to auto-fix formatting.
 - Keep v0.1 read-only unless a proposal explicitly changes the permission model.
 - Load `dist/` unpacked for manual browser testing; do not load the repo root.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,96 @@
+import js from '@eslint/js';
+
+export default [
+  js.configs.recommended,
+
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        // Browser extension APIs
+        chrome: 'readonly',
+        // Web standards
+        document: 'readonly',
+        window: 'readonly',
+        globalThis: 'readonly',
+        location: 'readonly',
+        navigator: 'readonly',
+        fetch: 'readonly',
+        Headers: 'readonly',
+        Request: 'readonly',
+        Response: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        console: 'readonly',
+        performance: 'readonly',
+        URL: 'readonly',
+        URLSearchParams: 'readonly',
+        DOMParser: 'readonly',
+        MutationObserver: 'readonly',
+        AbortController: 'readonly',
+        AbortSignal: 'readonly',
+        TextEncoder: 'readonly',
+        TextDecoder: 'readonly',
+        Blob: 'readonly',
+        FileReader: 'readonly',
+        atob: 'readonly',
+        btoa: 'readonly',
+        structuredClone: 'readonly',
+        crypto: 'readonly',
+      },
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', caughtErrors: 'none' }],
+      'no-console': 'off',
+      'no-var': 'error',
+      'prefer-const': 'warn',
+      'prefer-template': 'warn',
+      'no-throw-literal': 'warn',
+      'prefer-object-spread': 'warn',
+    },
+  },
+
+  {
+    files: ['scripts/**', 'tests/**', 'extension/lib/**'],
+    languageOptions: {
+      globals: {
+        // Node.js globals
+        process: 'readonly',
+        Buffer: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        require: 'readonly',
+        module: 'readonly',
+        exports: 'readonly',
+        console: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        global: 'readonly',
+      },
+    },
+  },
+
+  {
+    files: ['scripts/**', 'tests/**'],
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', caughtErrors: 'none', varsIgnorePattern: '^(assert|test)$' }],
+    },
+  },
+
+  {
+    ignores: [
+      'dist/',
+      'artifacts/',
+      'node_modules/',
+      '.hermes/',
+      'backups/',
+      'tmp/',
+      'docs/',
+    ],
+  },
+];

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "check:js": "node --check extension/sidepanel.js && node --check extension/background.js && node --check extension/content.js && node --check extension/request-permissions.js && node --check extension/voice-dictation.js && node --check extension/lib/common.mjs && node --check extension/lib/capabilities.mjs && node --check extension/lib/agent-discovery.mjs && node --check extension/lib/model-discovery.mjs && node --check extension/lib/gateway-ws.mjs && node --check extension/lib/dashboard-bridge.mjs && node --check scripts/windows-setup.mjs && node --check scripts/hermes-review-github-event.mjs && node --check scripts/hermes-review-watch.mjs",
     "check:manifest": "node scripts/check-manifest.mjs",
     "verify": "npm run test && npm run check:js && npm run check:manifest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "build": "node scripts/build.mjs",
     "setup:windows": "node scripts/windows-setup.mjs",
     "setup:windows:dry-run": "node scripts/windows-setup.mjs --dry-run --json",
@@ -30,5 +34,10 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9",
+    "eslint": "^9",
+    "prettier": "^3"
   }
 }


### PR DESCRIPTION
## Summary

Add ESLint (flat config, v9) and Prettier configuration to the project, plus matching npm scripts. This gives contributors and editors standard tooling for catching issues early and keeping a consistent code style.

## Changes

**`eslint.config.js`** — ESLint flat config with:
- `eslint:recommended` as the base rule set
- Browser (`chrome.*`, `document`, `fetch`, etc.) and Node.js (`process`, `Buffer`, etc.) globals scoped per file pattern
- Sensible extras: `no-var` (error), `prefer-const` (warn), `prefer-template` (warn), `no-throw-literal` (warn)
- Unused-vars warns with `_` prefix exemption
- Ignores `dist/`, `artifacts/`, `node_modules/`

**`.prettierrc`** — matching the project's existing style (single quotes, semicolons, 2-space indent, trailing commas, 120 print width)

**`package.json`** — four new scripts:
- `npm run lint` / `npm run lint:fix` (ESLint)
- `npm run format:check` / `npm run format` (Prettier)

**`CONTRIBUTING.md`** — updated with lint/format instructions

## Notes

- ESLint v9 uses flat config natively, no `.eslintrc.*` legacy format needed
- Config is intentionally permissive (warnings, not errors, for most styles) — catches real issues without blocking development
- After `npm install`, the tools are ready to use