### PR TITLE
fix: handle unloaded and failed context states in DOM chip

### DIFF
--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -91,7 +91,7 @@
         <form id="composer" class="composer">
           <label class="composer-label" for="promptInput">ASK HERMES</label>
           <button id="contextChip" class="context-chip" type="button" aria-expanded="false">
-            <span id="contextChipLabel">📎 DOM · 0 chars · ~0 tok</span>
+            <span id="contextChipLabel">📎 Loading...</span>
             <strong>preview</strong>
           </button>
           <div id="contextPreview" class="context-preview" hidden></div>

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -1621,18 +1621,31 @@ function renderContextWindow(userText = els.input?.value || '') {
     : `${formatNumber(sessionTokens)} estimated session tokens · unknown max context`;
   els.contextMeterFill.style.width = stats.modelContextTokens ? `${Math.min(100, Math.max(0, meter.percent))}%` : '0%';
 
-  const attachedParts = [stats.parts.selectedText, stats.parts.pageMetadata, stats.parts.youtubeTranscript, stats.parts.pageText]
-    .filter((part) => part?.enabled);
-  const attachedChars = attachedParts.reduce((total, part) => total + Number(part.chars || 0), 0);
-  const attachedTokens = attachedParts.reduce((total, part) => total + Number(part.estimatedTokens || 0), 0);
-  const adapter = currentContext.pageContext?.youtubeTranscript?.ok ? 'YouTube + DOM' : (currentContext.pageContext?.restricted ? 'Restricted' : 'DOM');
-  els.contextChipLabel.textContent = `📎 ${adapter} · ${formatNumber(attachedChars)} chars · ~${formatNumber(attachedTokens)} tok`;
-  els.contextChip.title = currentContext.activeTab?.url || '';
+  // Chip label: reflect page context state (loading → restricted → error → OK with stats)
+  const pc = currentContext?.pageContext;
+  if (!pc) {
+    els.contextChipLabel.textContent = '📎 Loading...';
+    els.contextChip.title = 'Page context not yet loaded';
+  } else if (pc.restricted) {
+    els.contextChipLabel.textContent = '📎 Restricted · N/A';
+    els.contextChip.title = pc.reason || (currentContext.activeTab?.url || 'Restricted page');
+  } else if (!pc.ok) {
+    els.contextChipLabel.textContent = '📎 Error · N/A';
+    els.contextChip.title = pc.error || 'Context capture failed';
+  } else {
+    const attachedParts = [stats.parts.selectedText, stats.parts.pageMetadata, stats.parts.youtubeTranscript, stats.parts.pageText]
+      .filter((part) => part?.enabled);
+    const attachedChars = attachedParts.reduce((total, part) => total + Number(part.chars || 0), 0);
+    const attachedTokens = attachedParts.reduce((total, part) => total + Number(part.estimatedTokens || 0), 0);
+    const adapter = pc?.youtubeTranscript?.ok ? 'YouTube + DOM' : 'DOM';
+    els.contextChipLabel.textContent = `📎 ${adapter} · ${formatNumber(attachedChars)} chars · ~${formatNumber(attachedTokens)} tok`;
+    els.contextChip.title = currentContext.activeTab?.url || '';
+  }
   els.contextPreview.textContent = [
     currentContext.activeTab?.title || '(unknown tab)',
     currentContext.activeTab?.url || '',
     '',
-    clampText(currentContext.pageContext?.selectedText || currentContext.pageContext?.text || currentContext.pageContext?.reason || currentContext.pageContext?.error || 'No readable page text captured yet.', 900),
+    clampText(pc?.selectedText || pc?.text || pc?.reason || pc?.error || 'No readable page text captured yet.', 900),
   ].filter(Boolean).join('\n');
 
   const rows = [


### PR DESCRIPTION
## Summary

Fixes the "DOM chip says 0 chars even on a normal page" issue by distinguishing three states the chip can be in: **loading**, **restricted/error**, and **normal operation**.

## The problem

Previously the chip displayed `📎 DOM · 0 chars · ~0 tok` in all states where text was 0 — even when the page context hadn't loaded yet, when the page was restricted, or when the context capture failed. This conflated three distinct situations:

1. **Initial load** — panel opened but `refreshContext()` hasn't completed yet
2. **Restricted page** — `chrome://`, `file://`, `about:blank`, or other non-injectable URLs
3. **Capture failure** — stale content script, tab not ready, or connection error
4. **Legitimate empty page** — page genuinely has no readable text

## The fix

**`extension/sidepanel.html`** — initial placeholder changed from `📎 DOM · 0 chars · ~0 tok` to `📎 Loading...`

**`extension/sidepanel.js`** (`renderContextWindow`) — chip now reflects the real state:

| Chip display | When |
|---|---|
| `📎 Loading...` | `pageContext` is null/undefined (not yet captured) |
| `📎 Restricted · N/A` | `pageContext.restricted === true` |
| `📎 Error · N/A` | `pageContext.ok === false` |
| `📎 DOM · X chars · ~Y tok` | Normal — page context captured successfully |

Also improves the context preview tooltip with better title attributes for each state.

## Testing

- **Normal page** (e.g. github.com) — shows `📎 DOM · X chars · ~Y tok` as before
- **`about:blank`** or new tab — shows `📎 Restricted · N/A`
- **`chrome://extensions/`** — shows `📎 Restricted · N/A`
- **Before first context refresh** — briefly shows `📎 Loading...`