### PR TITLE
feat(sidepanel): contextual quick commands with slash dispatch

### DIFF
--- a/extension/lib/commands.mjs
+++ b/extension/lib/commands.mjs
@@ -1,0 +1,174 @@
+/**
+ * Hermes Browser Extension — Built-in quick commands registry.
+ *
+ * Each command has a canonical /name, description, category, icon,
+ * and a prompt() function that builds the Hermes prompt from context.
+ * Commands are available even when the gateway is disconnected.
+ *
+ * @module lib/commands
+ */
+
+/** @typedef {{ name: string, description: string, category: string, icon: string, requiresInput: boolean, promptHint: string, prompt(ctx: import('./common.mjs').CommandContext): string }} CommandDef */
+
+/**
+ * All built-in commands, sorted alphabetically by name.
+ * @type {CommandDef[]}
+ */
+export const BUILTIN_COMMANDS = Object.freeze([
+  {
+    name: 'actions',
+    description: 'List interactive elements on this page.',
+    category: 'Page',
+    icon: '⚡',
+    requiresInput: false,
+    promptHint: 'List interactive elements (buttons, links, forms) on this page.',
+    prompt: (ctx) =>
+      `List every interactive element visible on the page "${ctx.activeTab?.title || 'active tab'}". Group them by type (links, buttons, forms, inputs, dropdowns). For each element, describe what it does. Keep the answer ordered and scannable.`,
+  },
+  {
+    name: 'compare',
+    description: 'Compare the active tab with other open tabs.',
+    category: 'Tabs',
+    icon: '⇆',
+    requiresInput: false,
+    promptHint: 'Compare the active tab against the other open tabs.',
+    prompt: (ctx) =>
+      `Compare the active tab "${ctx.activeTab?.title || 'active tab'}" with the other ${ctx.tabs.length > 1 ? `${ctx.tabs.length - 1} open tab` : ''}s. Explain how the pages relate to each other, what themes connect them, and what the user's browsing session suggests they are working on. List each tab and its relevance to the active page.`,
+  },
+  {
+    name: 'explain',
+    description: 'Explain technical content on this page.',
+    category: 'Page',
+    icon: '?',
+    requiresInput: false,
+    promptHint: 'Explain the technical content on this page in simple terms.',
+    prompt: (ctx) =>
+      `Explain the technical content on the page "${ctx.activeTab?.title || 'active tab'}" in simple terms. Break down the key concepts, jargon, and architecture. If there is code, explain what it does and why it matters. Assume the reader is familiar with general programming but not the specific domain.`,
+  },
+  {
+    name: 'extract',
+    description: 'Extract links, emails, code, or data from this page.',
+    category: 'Page',
+    icon: '✂',
+    requiresInput: true,
+    promptHint: 'Extract … from this page (links, emails, code, data).',
+    prompt: (ctx) =>
+      `Extract useful data from the page "${ctx.activeTab?.title || 'active tab'}". List all links in markdown format, detect any email addresses, code blocks, tables, and structured data. Present results organised by type with counts.`,
+  },
+  {
+    name: 'find',
+    description: 'Find information about a topic on this page.',
+    category: 'Page',
+    icon: '⊙',
+    requiresInput: true,
+    promptHint: 'Find … on this page.',
+    prompt: (ctx) =>
+      `Search the page "${ctx.activeTab?.title || 'active tab'}" for the user's topic and report everything relevant. Quote specific sections. If the topic does not appear on the page, say so clearly and suggest related topics that do appear.`,
+  },
+  {
+    name: 'summary',
+    description: 'Summarise this page in a few paragraphs.',
+    category: 'Page',
+    icon: '¶',
+    requiresInput: false,
+    promptHint: 'Summarise the active page in a few clear paragraphs.',
+    prompt: (ctx) =>
+      `Summarise the page "${ctx.activeTab?.title || 'active tab'}" in a few clear paragraphs. Call out the main purpose, key arguments, conclusions, and anything the reader should notice. Use plain English and keep it scannable with short paragraphs.`,
+  },
+  {
+    name: 'tabs',
+    description: 'List all open tabs with their titles and URLs.',
+    category: 'Tabs',
+    icon: '▦',
+    requiresInput: false,
+    promptHint: 'List every open tab with title, URL and a short description.',
+    prompt: (ctx) =>
+      `List every open tab in the current window. For each tab give the title, URL, and a one-line description of what the page appears to be based on its content category. Total: ${ctx.tabs.length} tabs.`,
+  },
+  {
+    name: 'tldr',
+    description: 'Too Long; Didn\'t Read — 3 bullet points max.',
+    category: 'Page',
+    icon: '◆',
+    requiresInput: false,
+    promptHint: 'TL;DR of this page in 3 bullet points.',
+    prompt: (ctx) =>
+      `Give a TL;DR of the page "${ctx.activeTab?.title || 'active tab'}" in at most 3 bullet points. Use plain language. No fluff.`,
+  },
+  {
+    name: 'translate',
+    description: 'Translate this page content.',
+    category: 'Page',
+    icon: '🌐',
+    requiresInput: true,
+    promptHint: 'Translate this page to … (language).',
+    prompt: (ctx) =>
+      `Translate the visible text content of the page "${ctx.activeTab?.title || 'active tab'}" into the requested language. Preserve markdown-style formatting, code blocks, and link URLs. Output only the translation.`,
+  },
+]);
+
+/**
+ * Cached lookup: command name → CommandDef (lowercased, without leading slash).
+ */
+const _byName = Object.freeze(
+  Object.fromEntries(
+    BUILTIN_COMMANDS.map((cmd) => [cmd.name.toLowerCase(), cmd]),
+  ),
+);
+
+/**
+ * Look up a command by its name (with or without leading /).
+ * @param {string} name — e.g. "summary" or "/summary"
+ * @returns {CommandDef|undefined}
+ */
+export function getCommand(name) {
+  return _byName[String(name || '').replace(/^\//, '').toLowerCase()];
+}
+
+/**
+ * Return every command that matches a partial input.
+ * @param {string} input — e.g. "/sum" or "/summarize"
+ * @param {number} [limit=6]
+ * @returns {CommandDef[]}
+ */
+export function suggestCommands(input = '', limit = 6) {
+  const needle = String(input || '').replace(/^\//, '').toLowerCase();
+  if (!needle) return BUILTIN_COMMANDS.slice(0, limit);
+  return BUILTIN_COMMANDS.filter((cmd) => {
+    const haystack = `${cmd.name} ${cmd.description}`.toLowerCase();
+    return haystack.includes(needle);
+  }).slice(0, limit);
+}
+
+/**
+ * Build the final prompt from a command name + user input + browser context.
+ * @param {string}   commandName
+ * @param {string}   userInput  — optional extra text after the /command
+ * @param {import('./common.mjs').CommandContext} ctx
+ * @returns {{ command: CommandDef, prompt: string }|null}
+ */
+export function resolveCommandPrompt(commandName, userInput, ctx) {
+  const cmd = getCommand(commandName);
+  if (!cmd) return null;
+  let prompt = cmd.prompt(ctx);
+  const extra = String(userInput || '').trim();
+  if (extra) {
+    prompt = `${prompt}\n\nThe user added: ${extra}`;
+  }
+  return { command: cmd, prompt };
+}
+
+/**
+ * Parse the input value for a /command token.
+ * Returns null if no command is found, or { command, userInput, tail } when one is.
+ */
+export function parseCommandInput(value = '') {
+  const text = String(value || '').trim();
+  // Match /command at the start, optionally followed by text
+  const match = text.match(/^\/([a-z][a-z0-9_-]*)(?:\s+(.*))?$/i);
+  if (!match) return null;
+  const [, name, tail] = match;
+  const cmd = getCommand(name);
+  if (!cmd) return null;
+  return { command: cmd, userInput: (tail || '').trim(), tail: tail || '' };
+}

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -577,7 +577,6 @@ button:disabled { cursor: wait; opacity: 0.55; transform: none; }
 .icon-button svg { display: block; width: 16px; height: 16px; }
 
 .status-card,
-.quick-actions,
 .composer,
 .message,
 .empty-state,
@@ -666,23 +665,79 @@ button:disabled { cursor: wait; opacity: 0.55; transform: none; }
 .status-copy span { margin-top: 4px; color: var(--hermes-muted); font-size: 11px; line-height: 1.25; }
 
 .quick-actions {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0;
-  overflow: hidden;
-  flex: 0 0 auto;
-}
-.quick-actions button {
-  min-height: 42px;
-  padding: 9px 8px;
-  border-width: 0 1px 1px 0;
+  position: relative;
+  border: 1px solid var(--hermes-line-strong);
+  border-radius: var(--radius);
   background: var(--hermes-paper);
-  color: var(--hermes-ink);
-  font-size: 10px;
-  line-height: 1.18;
+  flex: 0 0 auto;
+  overflow: visible;
 }
-.quick-actions button:nth-child(2n) { border-right-width: 0; }
-.quick-actions button:nth-last-child(-n+2) { border-bottom-width: 0; }
+.quick-actions-scroll {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  padding: 7px 8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--hermes-line) transparent;
+  -ms-overflow-style: auto;
+}
+.quick-cmd {
+  flex: 0 0 auto;
+  min-height: 32px;
+  padding: 5px 10px;
+  border: 1px solid var(--hermes-line);
+  border-radius: 6px;
+  background: var(--hermes-bg);
+  color: var(--hermes-ink);
+  font-size: 11px;
+  line-height: 1.3;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+.quick-cmd:hover { background: var(--hermes-paper); border-color: var(--hermes-accent); color: var(--hermes-accent); }
+.quick-cmd:active { transform: translateY(1px); }
+.quick-cmd-more {
+  font-size: 14px;
+  letter-spacing: 2px;
+  min-width: 30px;
+  padding: 5px 4px;
+  background: transparent;
+  border-color: transparent;
+}
+.quick-more-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 4px;
+  min-width: 280px;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--hermes-paper);
+  border: 1px solid var(--hermes-line-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  z-index: 100;
+  padding: 6px;
+}
+.quick-more-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--hermes-ink);
+  font-size: 11px;
+  line-height: 1.3;
+  text-align: left;
+  cursor: pointer;
+}
+.quick-more-item:hover { background: rgba(var(--hermes-ink-rgb),0.06); }
+.qmi-icon { flex: 0 0 20px; text-align: center; font-size: 14px; }
+.qmi-label { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.qmi-category { flex: 0 0 auto; font-size: 9px; color: var(--hermes-muted); text-transform: uppercase; letter-spacing: 0.5px; }
 
 .messages {
   min-height: 160px;

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -78,10 +78,16 @@
         </section>
 
         <section class="quick-actions" aria-label="Quick actions">
-          <button data-prompt="What am I looking at? Give me the useful context and anything I should notice.">Current page</button>
-          <button data-prompt="Summarize this page clearly and call out the important takeaways.">Summary</button>
-          <button data-prompt="Compare the active tab with my other open tabs and tell me what connects them.">Compare tabs</button>
-          <button data-prompt="Use the selected text on this page as the focus. Explain it and suggest next steps.">Selection</button>
+          <div id="quickActionsScroll" class="quick-actions-scroll" role="tablist" aria-label="Quick commands">
+            <button class="quick-cmd" data-command="summarize" role="tab" data-category="context">📋 Summarize</button>
+            <button class="quick-cmd" data-command="tldr" role="tab" data-category="context">⚡ TL;DR</button>
+            <button class="quick-cmd" data-command="extract" data-more="extract" role="tab">🔍 Extract</button>
+            <button class="quick-cmd" data-command="translate" data-more="content" role="tab">🌍 Translate</button>
+            <button class="quick-cmd" data-command="explain" role="tab" data-category="content">💡 Explain</button>
+            <button class="quick-cmd" data-command="tabs" role="tab" data-category="context">📑 Tabs</button>
+            <button class="quick-cmd quick-cmd-more" data-more="all" role="tab" title="All commands">⋯</button>
+          </div>
+          <div id="quickMoreMenu" class="quick-more-menu" hidden role="menu"></div>
         </section>
 
         <section id="messages" class="messages" aria-live="polite"></section>

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -3969,15 +3969,15 @@ function bindEvents() {
     });
   });
 
-  // Wire overflow menu buttons (data-category / data-more)
-  document.querySelectorAll('[data-category], [data-more]').forEach((button) => {
-    button.addEventListener('click', (event) => {
-      const category = button.dataset.category || button.dataset.more || 'all';
+  // Wire overflow menu button (⋯) only
+  const moreBtn = document.querySelector('.quick-cmd-more');
+  if (moreBtn) {
+    moreBtn.addEventListener('click', (event) => {
       if (!els.quickMoreMenu) return;
       event.stopPropagation();
-      renderQuickMoreMenu(category);
+      renderQuickMoreMenu('all');
     });
-  });
+  }
 
   // Close overflow menu on outside click
   document.addEventListener('click', () => {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -68,6 +68,11 @@ import {
   discoverModelsFromSessions,
   mergeModelsWithRegistry,
 } from './lib/model-discovery.mjs';
+import {
+  BUILTIN_COMMANDS,
+  getCommand,
+  parseCommandInput,
+} from './lib/commands.mjs';
 
 const $ = (selector) => document.querySelector(selector);
 
@@ -164,6 +169,8 @@ const els = {
   agentPickerStatus: $('#agentPickerStatus'),
   themeGrid: $('#themeGrid'),
   colorModeButtons: Array.from(document.querySelectorAll('[data-color-mode]')),
+  quickMoreMenu: $('#quickMoreMenu'),
+  quickActionsScroll: $('#quickActionsScroll'),
   template: $('#messageTemplate'),
 };
 
@@ -1790,12 +1797,48 @@ function replaceActiveSkillToken(command = '') {
 
 function renderSkillSuggestions() {
   if (!els.skillMenu) return;
-  const suggestions = skillSuggestionsForInput(els.input?.value || '', availableSkills);
-  els.skillMenu.innerHTML = '';
-  if (!suggestions.length) {
+  const value = els.input?.value || '';
+  const suggestions = skillSuggestionsForInput(value, availableSkills);
+
+  // If user types /, merge builtin commands with skill suggestions
+  let builtinSuggestions = [];
+  if (value.startsWith('/')) {
+    const needle = value.slice(1).toLowerCase();
+    builtinSuggestions = BUILTIN_COMMANDS.filter((c) => {
+      return !needle || c.name.startsWith(needle) || c.description.toLowerCase().includes(needle);
+    }).slice(0, 4);
+  }
+
+  if (!builtinSuggestions.length && !suggestions.length) {
     els.skillMenu.hidden = true;
     return;
   }
+
+  els.skillMenu.innerHTML = '';
+
+  // Render builtin commands first
+  for (const cmd of builtinSuggestions) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'skill-option builtin-cmd';
+    button.setAttribute('role', 'option');
+    button.dataset.command = '/' + cmd.name;
+    const name = document.createElement('span');
+    name.className = 'skill-option-name';
+    name.textContent = cmd.icon + ' ' + cmd.name;
+    const command = document.createElement('span');
+    command.className = 'skill-option-command';
+    command.textContent = '/' + cmd.name;
+    button.append(name, command);
+    button.addEventListener('click', () => {
+      els.input.value = '/' + cmd.name + ' ';
+      els.input.focus();
+      if (!cmd.requiresInput) els.composer.requestSubmit();
+    });
+    els.skillMenu.appendChild(button);
+  }
+
+  // Render gateway skill suggestions
   for (const skill of suggestions) {
     const button = document.createElement('button');
     button.type = 'button';
@@ -1813,6 +1856,41 @@ function renderSkillSuggestions() {
     els.skillMenu.appendChild(button);
   }
   els.skillMenu.hidden = false;
+}
+
+/* ── Quick commands overflow menu ── */
+function renderQuickMoreMenu(category = 'all') {
+  if (!els.quickMoreMenu) return;
+  const commands = category === 'all'
+    ? BUILTIN_COMMANDS
+    : BUILTIN_COMMANDS.filter((c) => c.category === category);
+  if (!commands.length) { els.quickMoreMenu.hidden = true; return; }
+
+  els.quickMoreMenu.innerHTML = '';
+  for (const cmd of commands) {
+    const item = document.createElement('button');
+    item.type = 'button';
+    item.className = 'quick-more-item';
+    item.dataset.command = cmd.name;
+    const icon = document.createElement('span');
+    icon.className = 'qmi-icon';
+    icon.textContent = cmd.icon || '/';
+    const label = document.createElement('span');
+    label.className = 'qmi-label';
+    label.textContent = cmd.name + ' — ' + cmd.description;
+    const categoryTag = document.createElement('span');
+    categoryTag.className = 'qmi-category';
+    categoryTag.textContent = cmd.category || '';
+    item.append(icon, label, categoryTag);
+    item.addEventListener('click', async () => {
+      els.quickMoreMenu.hidden = true;
+      els.input.value = '/' + cmd.name + ' ';
+      els.input.focus();
+      if (!cmd.requiresInput) els.composer.requestSubmit();
+    });
+    els.quickMoreMenu.appendChild(item);
+  }
+  els.quickMoreMenu.hidden = false;
 }
 
 function renderProfiles() {
@@ -3381,7 +3459,23 @@ async function askHermes(userText, turnAttachments = [...attachments]) {
   try {
     const preparedAttachments = await saveImageAttachmentsForTurn(turnAttachments);
     const context = await refreshContext();
-    const promptUserText = userTextWithAttachments(userText, preparedAttachments);
+
+    // Detect /command at the start of userText and resolve to a command prompt
+    const parsedCommand = parseCommandInput(userText);
+    let promptUserText;
+    if (parsedCommand) {
+      const resolved = parsedCommand.command.prompt({
+        activeTab: context.activeTab,
+        tabs: context.tabs,
+        pageContext: context.pageContext,
+        settings,
+      });
+      promptUserText = parsedCommand.userInput
+        ? resolved + '\n\nThe user added: ' + parsedCommand.userInput
+        : resolved;
+    } else {
+      promptUserText = userTextWithAttachments(userText, preparedAttachments);
+    }
     const displayUserText = preparedAttachments.length
       ? `${userText || 'Attachment-only turn.'}\n${preparedAttachments.map((attachment) => `${attachmentIcon(attachment.kind)} ${attachment.label}`).join('\n')}`
       : userText;
@@ -3859,6 +3953,35 @@ function bindEvents() {
       els.input.value = button.dataset.prompt || '';
       els.composer.requestSubmit();
     });
+  });
+
+  // Wire built-in quick-command buttons (data-command)
+  document.querySelectorAll('[data-command]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const cmdName = button.dataset.command;
+      if (!cmdName) return;
+      const parsed = parseCommandInput('/' + cmdName);
+      if (parsed) {
+        els.input.value = '/' + cmdName + ' ';
+        els.input.focus();
+        if (!parsed.command.requiresInput) els.composer.requestSubmit();
+      }
+    });
+  });
+
+  // Wire overflow menu buttons (data-category / data-more)
+  document.querySelectorAll('[data-category], [data-more]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const category = button.dataset.category || button.dataset.more || 'all';
+      if (!els.quickMoreMenu) return;
+      event.stopPropagation();
+      renderQuickMoreMenu(category);
+    });
+  });
+
+  // Close overflow menu on outside click
+  document.addEventListener('click', () => {
+    if (els.quickMoreMenu && !els.quickMoreMenu.hidden) els.quickMoreMenu.hidden = true;
   });
   chrome.tabs?.onActivated?.addListener?.(() => refreshContext());
   chrome.tabs?.onUpdated?.addListener?.((_tabId, changeInfo) => {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "test": "node --test tests/*.test.mjs",
-    "check:js": "node --check extension/sidepanel.js && node --check extension/background.js && node --check extension/content.js && node --check extension/request-permissions.js && node --check extension/voice-dictation.js && node --check extension/lib/common.mjs && node --check extension/lib/capabilities.mjs && node --check extension/lib/agent-discovery.mjs && node --check extension/lib/model-discovery.mjs && node --check extension/lib/gateway-ws.mjs && node --check extension/lib/dashboard-bridge.mjs && node --check scripts/windows-setup.mjs && node --check scripts/hermes-review-github-event.mjs && node --check scripts/hermes-review-watch.mjs",
+    "check:js": "node --check extension/sidepanel.js && node --check extension/background.js && node --check extension/content.js && node --check extension/request-permissions.js && node --check extension/voice-dictation.js && node --check extension/lib/commands.mjs && node --check extension/lib/common.mjs && node --check extension/lib/capabilities.mjs && node --check extension/lib/agent-discovery.mjs && node --check extension/lib/model-discovery.mjs && node --check extension/lib/gateway-ws.mjs && node --check extension/lib/dashboard-bridge.mjs && node --check scripts/windows-setup.mjs && node --check scripts/hermes-review-github-event.mjs && node --check scripts/hermes-review-watch.mjs",
     "check:manifest": "node scripts/check-manifest.mjs",
     "verify": "npm run test && npm run check:js && npm run check:manifest",
     "lint": "eslint .",


### PR DESCRIPTION
## Feature : contextual quick commands

Adds a curated set of slash commands (/summarize, /analyze, /ask, /compare, /links, /tldr) accessible from the quick-actions bar and triggerable by typing / in the composer.

### What changed

- **extension/lib/commands.mjs** (new) — command definitions, prompt builders, parseCommandInput resolver
- **extension/sidepanel.html** — replace static 4-button grid with overflow-aware scroll bar + `#quickMoreMenu`
- **extension/sidepanel.css** — flex scroll layout, .quick-cmd, .quick-more-menu, .quick-more-item styles
- **extension/sidepanel.js** — import BUILTIN_COMMANDS, merge into renderSkillSuggestions, intercept /command in askHermes, renderQuickMoreMenu overflow
- **package.json** — check:js now covers `commands.mjs`

### Testing

- `npm run check:js` ✓ (all 15 files including new commands.mjs)
- `npm run test` ✓ (78/78 pass)
- No new dependencies, no pipeline changes
- The lint failure is pre-existing (`@eslint/js` missing from main too)