### PR TITLE
fix: always run full Hermes model discovery

### DIFF
--- a/extension/lib/model-discovery.mjs
+++ b/extension/lib/model-discovery.mjs
@@ -91,6 +91,8 @@ export async function discoverModelsFromRegistry({
         seen.add(dedupeKey);
         const modelCaps = caps[modelId] || {};
         const uiId = slug ? `${slug}::${modelId}` : modelId;
+        const entryContext = Number(entry?.context_length || entry?.contextTokens || 0) || 0;
+        const capsContext = Number(modelCaps?.context_length || 0) || 0;
         models.push({
           id: uiId,
           rawModelId: modelId,
@@ -98,7 +100,7 @@ export async function discoverModelsFromRegistry({
           provider: slug || deriveProviderFromModelId(modelId),
           providerLabel,
           description: provider?.warning || provider?.source || '',
-          contextTokens: Number(entry?.context_length || entry?.contextTokens || 0) || 0,
+          contextTokens: entryContext || capsContext || 0,
           fast: typeof modelCaps.fast === 'boolean' ? modelCaps.fast : undefined,
           reasoning: typeof modelCaps.reasoning === 'boolean' ? modelCaps.reasoning : undefined,
           authenticated: provider?.authenticated !== false,

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -2081,7 +2081,7 @@ function applySelectedModel(selectedId, { persist = true, keepOpen = false } = {
   }
 }
 
-async function loadModels({ quiet = false, payload = null } = {}) {
+async function loadModels({ quiet = false, payload = null, refresh = false } = {}) {
   try {
     let data = payload;
     let registryModels = [];
@@ -2102,7 +2102,7 @@ async function loadModels({ quiet = false, payload = null } = {}) {
     if (data) {
       registryModels = normalizeHermesModels(data, settings.model);
     } else {
-      const registryResult = await discoverModelsFromRegistry({ apiFetch, readJsonResponse });
+      const registryResult = await discoverModelsFromRegistry({ apiFetch, readJsonResponse, refresh });
       if (registryResult.ok && registryResult.models.length) {
         registryModels = normalizeHermesModels(registryResult.models, settings.model);
         registrySource = 'registry';
@@ -4060,7 +4060,7 @@ async function testConnection() {
     const modelsResponse = await apiFetch('/v1/models', { method: 'GET' });
     const modelsPayload = await readJsonResponse(modelsResponse);
     if (!modelsResponse.ok) throw new Error(`Health OK, auth/model probe failed (${modelsResponse.status}): ${JSON.stringify(modelsPayload).slice(0, 500)}`);
-    await loadModels({ quiet: true, payload: modelsPayload });
+    await loadModels({ quiet: true });
     await loadSkills({ quiet: true });
     await loadProfiles({ quiet: true });
 
@@ -4182,7 +4182,7 @@ function bindEvents() {
   els.stopButton?.addEventListener('click', stopCurrentTurn);
   els.voiceButton?.addEventListener('click', toggleVoiceDictation);
   els.checkUpdatesButton?.addEventListener('click', checkForUpdates);
-  els.refreshModelsButton.addEventListener('click', () => loadModels());
+  els.refreshModelsButton.addEventListener('click', () => loadModels({ refresh: true }));
   els.refreshProfilesButton?.addEventListener('click', () => loadProfiles());
   els.profileSelect?.addEventListener('change', () => applySelectedProfile(els.profileSelect.value));
   els.refreshAgentsButton?.addEventListener('click', () => loadAgents());

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -347,6 +347,15 @@ test('connect and startup sync Hermes models, sessions, skills, and profiles fro
   assert.match(source, /apiFetch\(`\/api\/sessions\?limit=\$\{limit\}&offset=\$\{offset\}&include_children=true&order=recent`/);
 });
 
+test('connection test validates auth without bypassing full model discovery', () => {
+  const source = readFileSync(new URL('../extension/sidepanel.js', import.meta.url), 'utf8');
+  assert.match(source, /const modelsResponse = await apiFetch\('\/v1\/models', \{ method: 'GET' \}\);/);
+  assert.match(source, /if \(!modelsResponse\.ok\) throw new Error/);
+  assert.match(source, /await loadModels\(\{ quiet: true \}\);/);
+  assert.doesNotMatch(source, /loadModels\(\{ quiet: true, payload: modelsPayload \}\)/);
+  assert.match(source, /els\.refreshModelsButton\.addEventListener\('click', \(\) => loadModels\(\{ refresh: true \}\)\)/);
+});
+
 test('renderMarkdown produces safe rich text for headings, lists, tables, and links', () => {
   const html = renderMarkdown(`# Title\n\n**Quick read:**\n- One\n- [x] Two\n\n---\n\n| Name | Value |\n|---|---:|\n| MiniMax | 1M |\n\n[Docs](https://hermes-agent.nousresearch.com/docs) <script>alert(1)</script>`);
   assert.match(html, /<h1>Title<\/h1>/);

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -722,6 +722,35 @@ test('discoverModelsFromRegistry flattens /api/model/options provider inventory'
   assert.equal(result.models[2].contextTokens, 1000000);
 });
 
+test('discoverModelsFromRegistry picks up context_length from capabilities when model entries are bare strings', async () => {
+  const { discoverModelsFromRegistry } = await import('../extension/lib/model-discovery.mjs');
+  const apiFetch = async () => ({ ok: true, status: 200 });
+  const readJsonResponse = async () => ({
+    providers: [
+      {
+        slug: 'nous',
+        name: 'Nous Portal',
+        authenticated: true,
+        models: ['xiaomi/mimo-v2.5-pro', 'anthropic/claude-sonnet-4'],
+        capabilities: {
+          'xiaomi/mimo-v2.5-pro': { fast: false, reasoning: true, context_length: 1048576 },
+          'anthropic/claude-sonnet-4': { fast: true, reasoning: true, context_length: 200000 },
+        },
+      },
+    ],
+    model: 'xiaomi/mimo-v2.5-pro',
+    provider: 'nous',
+  });
+
+  const result = await discoverModelsFromRegistry({ apiFetch, readJsonResponse });
+  assert.equal(result.ok, true);
+  assert.equal(result.models.length, 2);
+  assert.equal(result.models[0].contextTokens, 1048576);
+  assert.equal(result.models[1].contextTokens, 200000);
+  assert.equal(result.models[0].reasoning, true);
+  assert.equal(result.models[0].fast, false);
+});
+
 test('normalizeHermesModels preserves camelCase registry labels for grouping', () => {
   const models = normalizeHermesModels([
     { id: 'openai-codex::gpt-5.5', rawModelId: 'gpt-5.5', label: 'GPT-5.5', provider: 'openai-codex', providerLabel: 'OpenAI Codex', source: 'registry' },


### PR DESCRIPTION
Summary:
- keep the connection auth probe but stop passing the /v1/models alias payload into model sync
- force the normal model discovery chain on connect so /api/model/options and session fallback can populate real providers/models
- make manual model refresh request a fresh registry fetch

Verification:
- npm test
- npm run check:js
- npm run check:manifest
- npm run build
- npm run verify
