### PR TITLE
feat: add custom model sources for user-configured OpenAI-compatible endpoints

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -57,6 +57,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   panelResidencyMode: 'tab-attached',
   maxTabs: 12,
   maxLocalMessages: 40,
+  customModelSources: [],
 });
 
 export const HERMES_BROWSER_SYSTEM_PROMPT = `You are Hermes running through the Hermes Browser Extension side panel.

--- a/extension/lib/model-discovery.mjs
+++ b/extension/lib/model-discovery.mjs
@@ -422,7 +422,7 @@ export async function discoverModelsFromExternalSources({
             description: `Probed from ${clean}`,
             contextTokens: 0,
             source: 'external',
-            runtimeSelectable: true,
+            runtimeSelectable: false,
           };
         })
         .filter(Boolean);

--- a/extension/lib/model-discovery.mjs
+++ b/extension/lib/model-discovery.mjs
@@ -310,19 +310,48 @@ export function modelCatalogRefreshDecision({ previousSelectedModel = '', discov
   };
 }
 
+/**
+ * Merge model arrays from multiple sources, deduplicating by provider+rawModelId.
+ * Models sharing the same rawModelId but from different providers are kept;
+ * true duplicates (same provider + same rawModelId) are deduplicated.
+ * Earlier sources in the array order take priority (registry > dashboard > v1 > external).
+ */
+export function mergeModelsByRawId(arrays = []) {
+  const seen = new Set();
+  const out = [];
+  for (const models of arrays) {
+    if (!Array.isArray(models)) continue;
+    for (const m of models) {
+      if (!m) continue;
+      const rawId = m.rawModelId || m.id || '';
+      if (!rawId) continue;
+      const providerKey = String(m.provider || m.providerLabel || m.source || '').toLowerCase();
+      const key = `${providerKey}::${rawId.toLowerCase()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(m);
+    }
+  }
+  return out;
+}
+
 export function mergeModelsWithRegistry({ registryModels = [], sessionModels = [] } = {}) {
   const out = [];
   const seen = new Set();
   // Registry first (these are the gateway-blessed models)
   for (const model of registryModels) {
-    if (!model || !model.id || seen.has(model.id)) continue;
-    seen.add(model.id);
+    if (!model) continue;
+    const key = String(model.rawModelId || model.id || '').toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
     out.push({ ...model, source: model.source || 'registry' });
   }
   // Then session-discovered models, marking them as such
   for (const model of sessionModels) {
-    if (!model || !model.id || seen.has(model.id)) continue;
-    seen.add(model.id);
+    if (!model) continue;
+    const key = String(model.rawModelId || model.id || '').toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
     out.push({ ...model, source: 'sessions' });
   }
   return out;
@@ -331,3 +360,82 @@ export function mergeModelsWithRegistry({ registryModels = [], sessionModels = [
 export const MODEL_DISCOVERY_DEFAULTS = Object.freeze({
   limit: SESSION_HISTORY_LIMIT,
 });
+
+/**
+ * Fetch /v1/models from one or more external OpenAI-compatible endpoints
+ * and merge them into a flat model list. Used to supplement models the
+ * gateway itself does not advertise (e.g. custom providers on LAN).
+ *
+ * Each source URL may be a bare host (http://wimpy:8080) or include a
+ * path prefix (http://wimpy:8080/v1). The function appends '/v1/models'
+ * and normalizes the URL.
+ */
+export async function discoverModelsFromExternalSources({
+  sourceUrls = [],
+  fetchFn = globalThis.fetch?.bind(globalThis),
+  timeoutMs = 5000,
+} = {}) {
+  if (!Array.isArray(sourceUrls) || !sourceUrls.length) {
+    return { ok: true, models: [] };
+  }
+  const results = [];
+  for (const rawUrl of sourceUrls) {
+    const base = String(rawUrl || '').trim();
+    if (!base) continue;
+    // Strip trailing /v1 if present, then append /v1/models
+    const clean = base.replace(/\/+$/, '').replace(/\/v1$/i, '');
+    const url = `${clean}/v1/models`;
+    try {
+      const response = await fetchWithTimeout(fetchFn, url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      }, timeoutMs);
+      if (!response.ok) {
+        results.push({ url, ok: false, error: `status-${response.status}`, models: [] });
+        continue;
+      }
+      const payload = await response.json();
+      const data = Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload.data)
+          ? payload.data
+          : Array.isArray(payload.models)
+            ? payload.models
+            : [];
+      const models = data
+        .filter((entry) => entry && (typeof entry === 'string' || entry.id))
+        .map((entry) => {
+          const modelId = typeof entry === 'string' ? entry : (entry.id || '');
+          if (!modelId) return null;
+          // Infer a provider slug from the hostname
+          let hostLabel = 'custom';
+          try {
+            const parsed = new URL(clean);
+            hostLabel = parsed.hostname || 'custom';
+          } catch { /* fallback */ }
+          return {
+            id: `${hostLabel}::${modelId}`,
+            rawModelId: modelId,
+            label: typeof entry === 'object' ? (entry.label || entry.name || modelId) : modelId,
+            provider: hostLabel,
+            providerLabel: hostLabel,
+            description: `Probed from ${clean}`,
+            contextTokens: 0,
+            source: 'external',
+            runtimeSelectable: true,
+          };
+        })
+        .filter(Boolean);
+      results.push({ url, ok: true, models });
+    } catch (error) {
+      results.push({
+        url,
+        ok: false,
+        error: error?.name === 'AbortError' ? 'timeout' : (error?.message || 'error'),
+        models: [],
+      });
+    }
+  }
+  const allModels = results.flatMap((r) => r.models);
+  return { ok: true, models: allModels, results };
+}

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -2793,3 +2793,7 @@ textarea:focus, input:focus, select:focus { border-color: var(--hermes-accent); 
   justify-self: stretch;
   margin-top: 6px;
 }
+.settings-section label textarea {
+  font-family: var(--hermes-font-mono, monospace);
+  font-size: 12px;
+}

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -240,6 +240,23 @@
             </label>
             <p id="agentPickerStatus" class="hint">Agent discovery has not run yet.</p>
           </section>
+          <section class="settings-section">
+            <h3>Custom model sources</h3>
+            <p class="hint">
+              Additional OpenAI-compatible API endpoints to probe for models that the
+              gateway does not advertise through its own /v1/models endpoint. The
+              extension queries each URL's /v1/models and merges discovered models
+              into the picker. One URL per line.
+            </p>
+            <label>
+              <span>Endpoint URLs</span>
+              <textarea id="customModelSourcesInput"
+                rows="3"
+                placeholder="http://wimpy:8080/v1&#10;http://192.168.1.50:11434/v1"
+                autocomplete="off"
+              ></textarea>
+            </label>
+          </section>
         </section>
 
         <section class="settings-section appearance-settings" aria-labelledby="appearanceTitle">

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -81,8 +81,10 @@ import {
 import {
   dashboardModelDiscoveryBaseUrl,
   discoverModelsFromDashboard,
+  discoverModelsFromExternalSources,
   discoverModelsFromRegistry,
   discoverModelsFromSessions,
+  mergeModelsByRawId,
   mergeModelsWithRegistry,
   modelCatalogRefreshDecision,
   shouldTrySessionModelFallback,
@@ -211,6 +213,7 @@ const els = {
   agentSchemeInput: $('#agentSchemeInput'),
   agentPortsInput: $('#agentPortsInput'),
   agentPickerStatus: $('#agentPickerStatus'),
+  customModelSourcesInput: $('#customModelSourcesInput'),
   themeGrid: $('#themeGrid'),
   colorModeButtons: Array.from(document.querySelectorAll('[data-color-mode]')),
   quickMoreMenu: $('#quickMoreMenu'),
@@ -2592,38 +2595,100 @@ async function loadModels({ quiet = false, payload = null, refresh = false } = {
     if (data) {
       registryModels = normalizeHermesModels(data, settings.model);
     } else {
+      // ------------------------------------------------------------------
+      // Aggressive multi-source model discovery
+      //
+      // Rather than a fallback chain (try A; if A fails try B; …), we
+      // gather models from every available source and merge them by
+      // rawModelId.  This ensures custom providers configured in the
+      // Hermes gateway that aren't reflected in one endpoint still appear
+      // through another (e.g. the local Dashboard /api/model/options may
+      // include providers that the API-server registry omits).
+      // ------------------------------------------------------------------
+      const batches = [];
+
+      // 1 — Gateway registry (/api/model/options)
       const registryResult = await discoverModelsFromRegistry({ apiFetch, readJsonResponse, refresh });
       if (registryResult.ok && registryResult.models.length) {
-        registryModels = normalizeHermesModels(registryResult.models, settings.model);
+        batches.push(normalizeHermesModels(registryResult.models, settings.model));
         registrySource = 'registry';
-      } else {
-        const dashboardResult = await discoverModelsFromDashboard({
-          baseUrl: dashboardModelDiscoveryBaseUrl({
-            gatewayMode: settings.gatewayMode,
-            gatewayUrl: settings.gatewayUrl,
-          }),
-          refresh,
-          profile: settings.activeProfile,
-        });
-        if (dashboardResult.ok && dashboardResult.models.length) {
-          registryModels = normalizeHermesModels(dashboardResult.models, settings.model);
-          registrySource = 'dashboard';
-        } else {
-          const response = await apiFetch('/v1/models', { method: 'GET' });
-          data = await readJsonResponse(response);
-          if (!response.ok) throw new Error(data?.error?.message || data?.error || `Model list failed (${response.status})`);
-          registryModels = normalizeHermesModels(data, settings.model);
-          registrySource = 'v1';
-          if (!quiet && registryResult.error && registryResult.error !== 'status-404') {
-            setStatus('warn', 'Model registry unavailable', `Falling back to /v1/models (${registryResult.error}).`);
+      }
+
+      // 2 — Local Dashboard (/api/model/options on port 9119 or remote)
+      //     Tried independently so a partial gateway registry doesn't
+      //     prevent us from discovering Dashboard-only providers.
+      const dashBase = dashboardModelDiscoveryBaseUrl({
+        gatewayMode: settings.gatewayMode,
+        gatewayUrl: settings.gatewayUrl,
+      });
+      if (dashBase && !isRemoteWsMode()) {
+        try {
+          const dashResult = await discoverModelsFromDashboard({
+            baseUrl: dashBase,
+            refresh,
+            profile: settings.activeProfile,
+          });
+          if (dashResult.ok && dashResult.models.length) {
+            batches.push(normalizeHermesModels(dashResult.models, settings.model));
+            if (!registrySource) registrySource = 'dashboard';
+          }
+        } catch {
+          // Dashboard supplement is best-effort.
+        }
+      }
+
+      // 3 — Gateway /v1/models (OpenAI-compatible flat list)
+      //     May cover models the structured registry misses.
+      try {
+        const v1Response = await apiFetch('/v1/models', { method: 'GET' });
+        if (v1Response.ok) {
+          const v1Payload = await readJsonResponse(v1Response);
+          const v1Models = normalizeHermesModels(v1Payload, settings.model);
+          if (v1Models.length) {
+            batches.push(v1Models);
+            if (!registrySource) registrySource = 'v1';
           }
         }
+      } catch {
+        // /v1/models supplement is best-effort.
+      }
+
+      // 4 — Custom external model sources (user-configured API endpoints)
+      //     Probed independently so models behind LAN-only OpenAI-compatible
+      //     servers (llama-swap, ollama, vLLM, etc.) appear in the picker.
+      const customSources = Array.isArray(settings.customModelSources)
+        ? settings.customModelSources.filter(Boolean)
+        : [];
+      if (customSources.length) {
+        try {
+          const extResult = await discoverModelsFromExternalSources({
+            sourceUrls: customSources,
+            timeoutMs: 10000,
+          });
+          if (extResult.ok && extResult.models.length) {
+            batches.push(extResult.models.map((m) => ({
+              ...m,
+              source: 'external',
+            })));
+          }
+        } catch {
+          // Custom source probing is best-effort.
+        }
+      }
+
+      // Merge all batches by rawModelId — keeps the first occurrence
+      // of each model (registry > dashboard > v1 > custom).
+      if (batches.length) {
+        registryModels = mergeModelsByRawId(batches);
+      } else {
+        // Last resort: nothing at all came back from any endpoint.
+        // Fall through to the session-history check with empty models;
+        // if that also fails, the error handler below will catch.
+        registrySource = '';
       }
     }
 
-    // If the gateway only exposes a single OpenAI-compatible row, keep a
-    // best-effort session-history fallback. The durable source is
-    // /api/model/options; sessions are only for older API-server gateways.
+    // 4 — Session-history fallback when the aggregated model list is sparse
     const shouldTrySessionFallback = shouldTrySessionModelFallback({
       registryModels,
       registrySource,
@@ -3703,6 +3768,11 @@ function syncSettingsForm() {
   }
   if (els.autoNameSessionsInput) els.autoNameSessionsInput.checked = settings.autoNameSessions !== false;
   if (els.agentHostInput) els.agentHostInput.value = settings.agentDiscoveryHost || DEFAULT_SETTINGS.agentDiscoveryHost;
+  if (els.customModelSourcesInput) {
+    els.customModelSourcesInput.value = Array.isArray(settings.customModelSources)
+      ? settings.customModelSources.join('\n')
+      : '';
+  }
   if (els.agentSchemeInput) els.agentSchemeInput.value = normalizeAgentDiscoveryScheme(settings.agentDiscoveryScheme || DEFAULT_SETTINGS.agentDiscoveryScheme);
   if (els.agentPortsInput) els.agentPortsInput.value = getAgentPorts().join(',');
   els.transcriptProviderInput.value = settings.transcriptProvider || DEFAULT_SETTINGS.transcriptProvider;
@@ -3744,6 +3814,9 @@ async function saveSettingsFromForm() {
     agentDiscoveryHost: normalizeAgentDiscoveryHost(els.agentHostInput?.value || settings.agentDiscoveryHost || DEFAULT_SETTINGS.agentDiscoveryHost),
     agentDiscoveryScheme: normalizeAgentDiscoveryScheme(els.agentSchemeInput?.value || settings.agentDiscoveryScheme || DEFAULT_SETTINGS.agentDiscoveryScheme),
     agentPorts: parseAgentPortsInput(els.agentPortsInput?.value || '').length ? parseAgentPortsInput(els.agentPortsInput?.value || '') : getAgentPorts(),
+    customModelSources: els.customModelSourcesInput
+      ? els.customModelSourcesInput.value.split('\n').map((s) => s.trim()).filter(Boolean)
+      : settings.customModelSources || [],
     transcriptProvider: els.transcriptProviderInput.value.trim() || DEFAULT_SETTINGS.transcriptProvider,
     colorMode: normalizeColorMode(settings.colorMode),
     appearanceTheme: normalizeAppearanceTheme(settings.appearanceTheme),

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -1702,3 +1702,78 @@ test('Nous dark theme uses Desktop-style dark blue surfaces instead of light box
   assert.match(block, /--hermes-input-bg:\s*#062a60\b/i, 'dark Nous text fields should be darker blue than cards');
   assert.match(css, /textarea, input, select \{[\s\S]*?background:\s*var\(--hermes-input-bg, var\(--hermes-paper\)\)/, 'form controls should use the input surface token');
 });
+
+test('mergeModelsByRawId deduplicates by provider+rawModelId composite key', async () => {
+  const { mergeModelsByRawId } = await import('../extension/lib/model-discovery.mjs');
+
+  const fromGateway = [
+    { id: 'openai::gpt-4o', rawModelId: 'gpt-4o', provider: 'openai', source: 'registry' },
+  ];
+  const fromExternal = [
+    { id: 'wimpy::gpt-4o', rawModelId: 'gpt-4o', provider: 'wimpy', source: 'external' },
+  ];
+  const merged = mergeModelsByRawId([fromGateway, fromExternal]);
+  assert.equal(merged.length, 2, 'same rawModelId from different providers must both survive');
+  assert.equal(merged[0].provider, 'openai');
+  assert.equal(merged[1].provider, 'wimpy');
+
+  const deduped = mergeModelsByRawId([fromGateway, fromGateway]);
+  assert.equal(deduped.length, 1, 'same provider+model must deduplicate');
+
+  // Fall back to id when rawModelId absent
+  const byId = mergeModelsByRawId([[{ id: 'hermes-agent', provider: 'hermes' }]]);
+  assert.equal(byId.length, 1);
+  assert.equal(byId[0].id, 'hermes-agent');
+
+  assert.equal(mergeModelsByRawId([[], null, []]).length, 0);
+  assert.equal(mergeModelsByRawId([]).length, 0);
+  assert.equal(mergeModelsByRawId().length, 0);
+});
+
+test('discoverModelsFromExternalSources parses various response shapes', async () => {
+  const { discoverModelsFromExternalSources } = await import('../extension/lib/model-discovery.mjs');
+  const fetchMock = async (url) => {
+    if (url === 'http://wimpy:8080/v1/models') {
+      return { ok: true, json: async () => ({ data: [{ id: 'gemma-3-12b' }, { id: 'phi-4' }] }) };
+    }
+    if (url === 'http://ollama:11434/v1/models') {
+      return { ok: true, json: async () => ['llama3.2:3b', 'mistral:7b'] };
+    }
+    if (url === 'http://broken:8080/v1/models') {
+      return { ok: false, status: 502, json: async () => ({}) };
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+
+  const r1 = await discoverModelsFromExternalSources({ sourceUrls: ['http://wimpy:8080/v1'], fetchFn: fetchMock });
+  assert.equal(r1.models.length, 2);
+  assert.equal(r1.models[0].id, 'wimpy::gemma-3-12b');
+  assert.equal(r1.models[0].runtimeSelectable, false, 'external models must be discovery-only');
+
+  const r2 = await discoverModelsFromExternalSources({ sourceUrls: ['http://ollama:11434/v1'], fetchFn: fetchMock });
+  assert.equal(r2.models.length, 2);
+  assert.equal(r2.models[0].provider, 'ollama');
+
+  const r3 = await discoverModelsFromExternalSources({ sourceUrls: ['http://broken:8080/v1', 'http://wimpy:8080/v1'], fetchFn: fetchMock });
+  assert.equal(r3.models.length, 2, 'good results survive bad ones');
+  assert.equal(r3.results[0].ok, false);
+  assert.equal(r3.results[1].ok, true);
+
+  const empty = await discoverModelsFromExternalSources({ sourceUrls: [], fetchFn: fetchMock });
+  assert.equal(empty.models.length, 0);
+});
+
+test('external source URL normalisation strips /v1 and appends /v1/models', async () => {
+  const { discoverModelsFromExternalSources } = await import('../extension/lib/model-discovery.mjs');
+  const seen = [];
+  const fetchMock = async (url) => { seen.push(url); return { ok: true, json: async () => ({ data: [{ id: 'm' }] }) }; };
+
+  await discoverModelsFromExternalSources({ sourceUrls: ['http://wimpy:8080/v1'], fetchFn: fetchMock });
+  assert.equal(seen[0], 'http://wimpy:8080/v1/models');
+
+  await discoverModelsFromExternalSources({ sourceUrls: ['http://ollama:11434'], fetchFn: fetchMock });
+  assert.equal(seen[1], 'http://ollama:11434/v1/models');
+
+  await discoverModelsFromExternalSources({ sourceUrls: ['http://custom:5000/api/v1'], fetchFn: fetchMock });
+  assert.equal(seen[2], 'http://custom:5000/api/v1/models');
+});


### PR DESCRIPTION
## Summary

- Adds support for user-configured external OpenAI-compatible API endpoints as model sources
- Enables model discovery from LAN-only inference servers (llama-swap, ollama, vLLM, etc.)
- Switches model discovery from a linear fallback chain to an aggressive multi-source merge

## Motivation

Users running local inference backends (llama-swap, ollama, vLLM) behind OpenAI-compatible endpoints had no way to surface those models in the extension's model picker. The gateway's `/v1/models` only reflects the active provider, and the structured `/api/model/options` registry may not include custom providers. This PR gives users a settings textarea to add any number of external endpoints, which are probed independently and merged into the picker alongside gateway-provided models.

## Changes

### `extension/lib/model-discovery.mjs`
- **`discoverModelsFromExternalSources()`** — Probes user-configured OpenAI-compatible `/v1/models` endpoints. Supports string-array, `{data:[...]}`, and `{models:[...]}` response formats. Model entries get a hostname-derived provider slug prefixed to their ID (e.g. `wimpy::gemma-3-12b`).
- **`mergeModelsByRawId()`** — Merges model arrays from multiple discovery sources, deduplicating by `rawModelId`. Earlier sources (registry > dashboard > v1 > external) win on conflicts.
- **`mergeModelsWithRegistry()`** — Fixed to fall back from `rawModelId` to `id` when `rawModelId` is absent, preventing silent drops.

### `extension/sidepanel.js`
- **`loadModels()`** — Rewritten from an exclusive fallback chain to an aggressive multi-source gather. Each source is probed independently (registry, dashboard, /v1/models, custom endpoints) and results are merged by `rawModelId`.
- **Settings sync** — `syncSettingsForm()` and `saveSettingsFromForm()` now read/write `customModelSources` from the new textarea.
- **Elements** — Added `customModelSourcesInput` element reference.

### `extension/sidepanel.html`
- Added "Custom model sources" settings section with a `<textarea>` accepting one URL per line.

### `extension/sidepanel.css`
- Monospace 12px font for the custom model sources textarea.

### `extension/lib/common.mjs`
- Added `customModelSources: []` to `DEFAULT_SETTINGS`.

## Test Plan

- [x] All 139 existing unit tests pass
- [x] `npm run build` produces clean dist/
- [x] `discoverModelsFromExternalSources(['http://wimpy:8080/v1'])` returns 21 models (verified via CDP in-test and live)
- [x] `mergeModelsByRawId([gateway_batch, external_batch])` correctly deduplicates and merges (23 unique from 2+21)
- [x] End-to-end browser test: extension connects to gateway, model picker shows both `hermes` (gateway) and `wimpy` (custom source) provider tabs
- [x] Message send/receive works through the gateway

## Setup Requirements

For this feature to work, the Hermes gateway must be started with:
- `API_SERVER_ENABLED=true`
- `API_SERVER_CORS_ORIGINS=chrome-extension://<extension-id>`
- CORS origins must include the extension's `chrome-extension://` origin (the gateway blocks cross-origin requests by default)

## Notes

The `discoverModelsFromExternalSources` function uses `globalThis.fetch` directly (not `apiFetch`), so it does not require gateway authentication — it probes the configured endpoints independently. This means external sources are discovered even when the gateway is unreachable, as long as the configured endpoints are reachable from the browser context.