### PR TITLE
feat: add native sidebar support for Opera browser

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -37,6 +37,7 @@ async function refreshPanelResidencyModeFromStorage() {
 }
 
 async function setActionClickSidePanelBehavior() {
+  if (globalThis.opr?.sidebarAction || globalThis.chrome?.sidebarAction) return;
   if (!chrome.sidePanel?.setPanelBehavior) return;
   await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 }
@@ -111,6 +112,42 @@ async function openHermesPanel(tab) {
     tabId: useTabAttached ? tabId : null,
     defaultPath: defaultPanelPath,
   });
+
+  // Try Opera native sidebar Action if available
+  const sidebarAction = globalThis.opr?.sidebarAction || globalThis.chrome?.sidebarAction;
+  if (sidebarAction && typeof sidebarAction.open === 'function') {
+    try {
+      await new Promise((resolve, reject) => {
+        try {
+          const res = sidebarAction.open((result) => {
+            if (chrome.runtime.lastError) {
+              reject(chrome.runtime.lastError);
+            } else {
+              resolve(result);
+            }
+          });
+          if (res && typeof res.then === 'function') {
+            res.then(resolve, reject);
+          }
+        } catch (e) {
+          try {
+            const res2 = sidebarAction.open();
+            if (res2 && typeof res2.then === 'function') {
+              res2.then(resolve, reject);
+            } else {
+              resolve();
+            }
+          } catch (innerErr) {
+            reject(innerErr);
+          }
+        }
+      });
+      return;
+    } catch (sidebarError) {
+      console.warn('[Hermes Browser] Opera sidebar action open failed:', sidebarError);
+    }
+  }
+
   const sidePanelCanOpen = Boolean(chrome.sidePanel?.open);
 
   try {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -43,6 +43,16 @@
   "side_panel": {
     "default_path": "sidepanel.html"
   },
+  "sidebar_action": {
+    "default_icon": {
+      "16": "assets/icons/icon-16.png",
+      "32": "assets/icons/icon-32.png",
+      "48": "assets/icons/icon-48.png",
+      "128": "assets/icons/icon-128.png"
+    },
+    "default_title": "Hermes Browser Extension",
+    "default_panel": "sidepanel.html"
+  },
   "commands": {
     "_execute_action": {
       "suggested_key": {
@@ -50,6 +60,13 @@
         "mac": "Alt+H"
       },
       "description": "Open Hermes Browser Extension"
+    },
+    "_execute_sidebar_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+H",
+        "mac": "Command+Shift+H"
+      },
+      "description": "Open Hermes Browser Sidebar"
     }
   },
   "content_scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,16 @@
   "side_panel": {
     "default_path": "extension/sidepanel.html"
   },
+  "sidebar_action": {
+    "default_icon": {
+      "16": "extension/assets/icons/icon-16.png",
+      "32": "extension/assets/icons/icon-32.png",
+      "48": "extension/assets/icons/icon-48.png",
+      "128": "extension/assets/icons/icon-128.png"
+    },
+    "default_title": "Hermes Browser Extension",
+    "default_panel": "extension/sidepanel.html"
+  },
   "commands": {
     "_execute_action": {
       "suggested_key": {
@@ -50,6 +60,13 @@
         "mac": "Alt+H"
       },
       "description": "Open Hermes Browser Extension"
+    },
+    "_execute_sidebar_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+H",
+        "mac": "Command+Shift+H"
+      },
+      "description": "Open Hermes Browser Sidebar"
     }
   },
   "content_scripts": [

--- a/scripts/check-manifest.mjs
+++ b/scripts/check-manifest.mjs
@@ -78,6 +78,13 @@ if (manifest.permissions?.includes('microphone') || manifest.optional_permission
   errors.push('microphone is a Web Permission name, not a Chrome extension manifest permission; use the request-permissions page instead');
 }
 if (!manifest.host_permissions?.includes('http://127.0.0.1/*')) errors.push('localhost gateway host permission missing');
+if (!manifest.sidebar_action) errors.push('sidebar_action missing for Opera support');
+if (manifest.sidebar_action?.default_panel !== manifest.side_panel?.default_path) {
+  errors.push('sidebar_action default_panel must match side_panel default_path');
+}
+if (rootManifest && !rootManifest.sidebar_action) {
+  errors.push('root manifest sidebar_action missing for Opera support');
+}
 
 const sourceCsp = manifest.content_security_policy?.extension_pages || '';
 const rootCsp = rootManifest?.content_security_policy?.extension_pages || '';


### PR DESCRIPTION
This PR adds native sidebar support for the Opera browser, allowing the extension to be loaded and run inside the left Opera Sidebar panel.

### Changes:
- Added 'sidebar_action' configuration to manifest.json and extension/manifest.json.
- Configured '_execute_sidebar_action' keyboard shortcut to toggle/open the Opera sidebar.
- Updated background.js to detect and open the Opera sidebar via 'opr.sidebarAction' or 'chrome.sidebarAction'.
- Added automated check-manifest assertions to ensure Opera sidebar_action keys are valid and aligned.
- Confirmed via 'npm run verify' and 'npm run lint' that all tests and linting check pass successfully.