### PR TITLE
fix(companion-plugin): handle content arrays in _last_user_message

### DIFF
--- a/companion-plugin/context_store.py
+++ b/companion-plugin/context_store.py
@@ -57,6 +57,24 @@ def _section_key(label: str) -> str:
     return label.strip().lower().replace(" ", "_").replace("/", "_")
 
 
+from typing import Any as _Any
+
+def _meaningful_text_from_content_list(parts: list[_Any]) -> str:
+    """Flatten a content array (OpenAI format) into a single string.
+
+    A content array looks like:
+        [{"type": "text", "text": "Hello"}, {"type": "image_url", ...}]
+    Returns the concatenated text parts for browser-context scanning.
+    """
+    chunks: list[str] = []
+    for part in parts:
+        if isinstance(part, dict) and part.get("type") == "text":
+            text = part.get("text", "")
+            if isinstance(text, str) and text.strip():
+                chunks.append(text)
+    return "\n".join(chunks)
+
+
 def _meaningful_section_text(lines: list[str] | None) -> str:
     if not lines:
         return ""

--- a/companion-plugin/context_store.py
+++ b/companion-plugin/context_store.py
@@ -8,6 +8,8 @@ Hermes restarts.
 
 from __future__ import annotations
 
+from typing import Any
+
 import hashlib
 import json
 import re
@@ -57,9 +59,7 @@ def _section_key(label: str) -> str:
     return label.strip().lower().replace(" ", "_").replace("/", "_")
 
 
-from typing import Any as _Any
-
-def _meaningful_text_from_content_list(parts: list[_Any]) -> str:
+def _meaningful_text_from_content_list(parts: list[Any]) -> str:
     """Flatten a content array (OpenAI format) into a single string.
 
     A content array looks like:

--- a/companion-plugin/hooks.py
+++ b/companion-plugin/hooks.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from .context_store import _meaningful_text_from_content_list as _content_list_to_str
+
 if TYPE_CHECKING:
     from .context_store import BrowserContextStore
 
@@ -36,10 +38,17 @@ def _ensure_store() -> BrowserContextStore:
 
 
 def _last_user_message(**kwargs: Any) -> str:
-    """Return the current/last user message from Hermes hook kwargs."""
+    """Return the current/last user message from Hermes hook kwargs.
+
+    Handles both plain string content and content arrays (OpenAI format
+    ``[{type: "text", text: "..."}, ...]``) used by modern Hermes
+    versions when attachments are present.
+    """
     user_message = kwargs.get("user_message")
     if isinstance(user_message, str):
         return user_message
+    if isinstance(user_message, list):
+        return _content_list_to_str(user_message)
 
     history = kwargs.get("conversation_history") or kwargs.get("messages") or []
     if not isinstance(history, list):
@@ -48,6 +57,8 @@ def _last_user_message(**kwargs: Any) -> str:
     for msg in reversed(history):
         if isinstance(msg, dict) and msg.get("role") == "user":
             content = msg.get("content", "")
+            if isinstance(content, list):
+                return _content_list_to_str(content)
             return str(content) if content else ""
     return ""
 


### PR DESCRIPTION
## The Bug

The companion plugin's `pre_llm_call` hook silently fails to detect browser context in messages that use content arrays (the OpenAI message format where `content` is a list of `{type, text}` objects instead of a plain string).

Modern Hermes versions use content arrays when attachments (images, files) are present in a message. The `_last_user_message` helper only handled `isinstance(content, str)`, so `str([{type: "text", text: "..."}])` returns `"[object Object]"` which does not contain the `UNTRUSTED_BROWSER_CONTEXT_START` marker, and the context cache remains empty.

## The Fix

1. **`companion-plugin/context_store.py`** — add `_meaningful_text_from_content_list()` helper that flattens content arrays into a single string by concatenating `.text` fields from each `type: "text"` part.

2. **`companion-plugin/hooks.py`** — update `_last_user_message()` to:
   - Check for content arrays in both `user_message` kwargs and `conversation_history` messages
   - Delegate array flattening to the new helper
