### PR TITLE
fix: redact credential-bearing URL parameters

### DIFF
--- a/extension/lib/browser-context-protocol.mjs
+++ b/extension/lib/browser-context-protocol.mjs
@@ -51,6 +51,7 @@ const SENSITIVE_URL_PATTERNS = [
   /\/payments?/i,
   /\/medical|healthcare|patient|mychart/i,
   /\/tax|irs\.gov|ssa\.gov/i,
+  /(?:^|[?#&;\s])(?:api[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|session[_-]?token|token|password|passwd|secret|private[_-]?key)=/i,
 ];
 
 export function clampText(value = '', maxChars = 12_000) {

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -126,6 +126,7 @@ const SENSITIVE_URL_PATTERNS = [
   /\/payments?/i,
   /\/medical|healthcare|patient|mychart/i,
   /\/tax|irs\.gov|ssa\.gov/i,
+  /(?:^|[?#&;\s])(?:api[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|session[_-]?token|token|password|passwd|secret|private[_-]?key)=/i,
 ];
 
 export function normalizeGatewayUrl(value = DEFAULT_SETTINGS.gatewayUrl) {

--- a/tests/browser-context-protocol.test.mjs
+++ b/tests/browser-context-protocol.test.mjs
@@ -31,7 +31,7 @@ test('buildBrowserContextPayload normalizes browser context into a stable protoc
       id: '7',
       active: true,
       title: '<img src=x onerror=alert(1)>',
-      url: 'https://example.com/private?api_key=browser-secret-value',
+      url: 'https://example.com/private/docs',
       favIconUrl: 'https://example.com/favicon.ico',
     },
     tabs: [
@@ -90,7 +90,8 @@ test('Browser Context Protocol restricts sensitive query and hash URL fragments'
       { id: 2, title: 'Docs Hash', url: 'https://example.com/docs#%77allet' },
       { id: 3, title: 'Encoded Path', url: 'https://example.com/%62ank' },
       { id: 4, title: 'Malformed Query', url: 'https://example.com/search?q=my%62ank%' },
-      { id: 5, title: 'Public Docs', url: 'https://example.com/docs/browser-context' },
+      { id: 5, title: 'Credential Query', url: 'https://example.com/docs?api_key=browser-secret-value#token=abc' },
+      { id: 6, title: 'Public Docs', url: 'https://example.com/docs/browser-context' },
     ],
     selectedTabs: [{ id: 2, title: 'Docs Hash', url: 'https://example.com/docs#%77allet' }],
     pageContext: { selectedText: '', text: '' },
@@ -103,7 +104,9 @@ test('Browser Context Protocol restricts sensitive query and hash URL fragments'
   assert.equal(payload.tabs[1].title, '(restricted tab)');
   assert.equal(payload.tabs[2].title, '(restricted tab)');
   assert.equal(payload.tabs[3].title, '(restricted tab)');
-  assert.equal(payload.tabs[4].title, 'Public Docs');
+  assert.equal(payload.tabs[4].title, '(restricted tab)');
+  assert.equal(payload.tabs[4].url, '(omitted by privacy guard)');
+  assert.equal(payload.tabs[5].title, 'Public Docs');
   assert.equal(payload.selectedTabs[0].url, '(omitted by privacy guard)');
 });
 

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -429,6 +429,8 @@ test('isRestrictedUrl blocks browser internals and sensitive account categories'
   assert.equal(isRestrictedUrl('https://example.com/docs#%77allet'), true);
   assert.equal(isRestrictedUrl('https://example.com/%62ank'), true);
   assert.equal(isRestrictedUrl('https://example.com/search?q=my%62ank%'), true);
+  assert.equal(isRestrictedUrl('https://example.com/docs?api_key=browser-secret-value#token=abc'), true);
+  assert.equal(isRestrictedUrl('https://example.com/docs?next=public'), false);
 });
 
 test('privacySafeTabForPrompt redacts sensitive tab titles and URLs before prompt assembly', () => {


### PR DESCRIPTION
## Summary

- Treat credential-like query/hash parameters as restricted URLs before Browser Context Protocol prompt assembly.
- Apply the same guard to shared URL privacy logic in `common.mjs`.
- Add regression tests for `api_key` / `token` query/hash leakage while preserving normal public URLs.

## Problem

`v0.1.10` blocks browser internals and obvious sensitive URL categories, but credential-like query/hash parameters can still pass through tab URL context.

Example before this patch:

```text
https://example.com/docs?api_key=browser-secret-value#token=abc
```

could appear in:

- `privacySafeTabForPrompt(...)`
- `summarizeTabs(...)`
- `buildBrowserContextPrompt(...)`

## Fix

Add this sensitive URL pattern to both privacy guards:

```js
/(?:^|[?#&;\s])(?:api[_-]?key|access[_-]?token|auth[_-]?token|refresh[_-]?token|session[_-]?token|token|password|passwd|secret|private[_-]?key)=/i
```

When matched, the tab is rendered as:

```text
(restricted tab)
(omitted by privacy guard)
```

## Tests

- Adds Browser Context Protocol regression coverage for credential-like query/hash URLs.
- Adds shared `isRestrictedUrl` coverage for `?api_key=...#token=...`.
- Preserves a normal public URL control case: `?next=public` remains unrestricted.

## Verification

Ran locally:

```text
npm run verify
npm run build
```

Results:

```text
npm run verify -> PASS, 309/309 tests
Manifest OK: Hermes Browser Extension 0.1.10
npm run build -> PASS
```

Also validated with a disposable Chromium profile that prompt payloads no longer include the credential-like URL string after this patch.

## Security note

This is a privacy hardening patch for accidental credential exposure through URL metadata. It does not change browser permissions or add new data collection.
