### PR TITLE
fix: remove audioCapture and prevent duplicate context menu items

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -301,8 +301,12 @@ async function queueOpenSessionRequest(message, sender) {
   return { ok: true, sessionId, surface };
 }
 
+let contextMenusConfigured = false;
+
 async function configureContextMenus() {
   if (!chrome.contextMenus?.create) return;
+  if (contextMenusConfigured) return;
+  contextMenusConfigured = true;
   await chrome.contextMenus.removeAll();
   chrome.contextMenus.create({
     id: CONTEXT_MENU_ROOT_ID,

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,9 +20,7 @@
     "storage",
     "tabs"
   ],
-  "optional_permissions": [
-    "audioCapture"
-  ],
+  "optional_permissions": [],
   "host_permissions": [
     "http://127.0.0.1/*",
     "http://localhost/*",


### PR DESCRIPTION
Two fixes for console errors on startup:

1. **Remove `audioCapture` from optional_permissions** — Chrome only allows audioCapture for packaged apps, not extensions. Including it generates a console warning every Service Worker start.

2. **Prevent duplicate context menu registration** — `configureContextMenus()` was called from both `onInstalled` and `onStartup`. Without a guard, `contextMenus.create()` could fire before `removeAll()` finished, producing 7× "Cannot create item with duplicate id" errors.

Both errors are cosmetic (non-breaking) but noisy in the console.