### PR TITLE
Add user-editable context menu items in settings

### DIFF
--- a/extension/app.css
+++ b/extension/app.css
@@ -708,5 +708,7 @@ button:disabled { cursor: not-allowed; opacity: 0.52; }
 .context-menu-mode-row { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
 .context-menu-mode-select { flex-shrink: 0; font-size: 11px; }
 .context-menu-mode-row select { font-size: 11px; }
+.context-menu-mode-note { font-size: 10px; color: var(--hermes-muted); }
+.context-menu-editor-notice { font-size: 11px; color: var(--hermes-danger, #b3261e); margin: 0; }
 .context-menu-prompt-input { flex: 1 1 100px; min-width: 0; font-size: 11px; }
 .context-menu-editor > button { align-self: flex-start; font-size: 11px; }

--- a/extension/app.css
+++ b/extension/app.css
@@ -690,3 +690,20 @@ button:disabled { cursor: not-allowed; opacity: 0.52; }
   .error-state h2 { font-size: 36px; }
   .web-settings-dialog section { grid-template-columns: 1fr; }
 }
+
+.context-menu-editor { margin-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.context-menu-editor h4 { margin: 0; font-size: 12px; font-weight: 600; color: var(--hermes-muted, #888); text-transform: uppercase; letter-spacing: 0.05em; }
+.context-menu-items-list { display: flex; flex-direction: column; gap: 6px; }
+.context-menu-item-row { border: 1px solid var(--hermes-border, rgba(0,0,0,0.1)); border-radius: 6px; padding: 8px; display: flex; flex-direction: column; gap: 6px; background: var(--hermes-surface, rgba(0,0,0,0.03)); }
+.context-menu-item-header { display: flex; align-items: center; gap: 6px; }
+.context-menu-item-header input[type="checkbox"] { margin: 0; flex-shrink: 0; }
+.context-menu-item-title { flex: 1; min-width: 0; }
+.context-menu-item-controls { display: flex; gap: 2px; flex-shrink: 0; }
+.context-menu-item-controls button { padding: 2px 6px; font-size: 12px; min-width: 24px; }
+.context-menu-item-detail { display: flex; flex-direction: column; gap: 4px; padding-left: 22px; }
+.context-menu-item-label { font-size: 11px; font-weight: 500; color: var(--hermes-muted, #888); }
+.context-menu-contexts-checkboxes { display: flex; flex-wrap: wrap; gap: 6px; }
+.context-menu-contexts-checkboxes label { font-size: 11px; display: inline-flex; align-items: center; gap: 2px; }
+.context-menu-mode-row { display: flex; gap: 6px; align-items: center; }
+.context-menu-mode-select { flex-shrink: 0; }
+.context-menu-prompt-input { flex: 1; min-width: 0; }

--- a/extension/app.css
+++ b/extension/app.css
@@ -692,18 +692,21 @@ button:disabled { cursor: not-allowed; opacity: 0.52; }
 }
 
 .context-menu-editor { margin-top: 12px; display: flex; flex-direction: column; gap: 8px; }
-.context-menu-editor h4 { margin: 0; font-size: 12px; font-weight: 600; color: var(--hermes-muted, #888); text-transform: uppercase; letter-spacing: 0.05em; }
+.context-menu-editor h4 { margin: 0; font-size: 10px; font-weight: 600; color: var(--hermes-muted); text-transform: uppercase; letter-spacing: 0.15em; }
 .context-menu-items-list { display: flex; flex-direction: column; gap: 6px; }
-.context-menu-item-row { border: 1px solid var(--hermes-border, rgba(0,0,0,0.1)); border-radius: 6px; padding: 8px; display: flex; flex-direction: column; gap: 6px; background: var(--hermes-surface, rgba(0,0,0,0.03)); }
-.context-menu-item-header { display: flex; align-items: center; gap: 6px; }
-.context-menu-item-header input[type="checkbox"] { margin: 0; flex-shrink: 0; }
-.context-menu-item-title { flex: 1; min-width: 0; }
+.context-menu-item-row { border: 1px solid var(--hermes-line); border-radius: 0; padding: 8px; display: flex; flex-direction: column; gap: 6px; background: rgba(var(--hermes-ink-rgb), 0.035); }
+.context-menu-item-header { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; }
+.context-menu-item-header input[type="checkbox"] { margin: 0; flex-shrink: 0; width: 14px; height: 14px; }
+.context-menu-item-title { flex: 1 1 120px; min-width: 0; font-size: 12px; }
 .context-menu-item-controls { display: flex; gap: 2px; flex-shrink: 0; }
-.context-menu-item-controls button { padding: 2px 6px; font-size: 12px; min-width: 24px; }
-.context-menu-item-detail { display: flex; flex-direction: column; gap: 4px; padding-left: 22px; }
-.context-menu-item-label { font-size: 11px; font-weight: 500; color: var(--hermes-muted, #888); }
-.context-menu-contexts-checkboxes { display: flex; flex-wrap: wrap; gap: 6px; }
-.context-menu-contexts-checkboxes label { font-size: 11px; display: inline-flex; align-items: center; gap: 2px; }
-.context-menu-mode-row { display: flex; gap: 6px; align-items: center; }
-.context-menu-mode-select { flex-shrink: 0; }
-.context-menu-prompt-input { flex: 1; min-width: 0; }
+.context-menu-item-controls button { padding: 2px 5px; font-size: 11px; min-width: 22px; line-height: 1.4; }
+.context-menu-item-detail { display: flex; flex-direction: column; gap: 4px; padding-left: 18px; }
+.context-menu-item-label { font-size: 9px; font-weight: 500; color: var(--hermes-muted); text-transform: uppercase; letter-spacing: 0.12em; }
+.context-menu-contexts-checkboxes { display: flex; flex-wrap: wrap; gap: 4px 6px; }
+.context-menu-contexts-checkboxes label { font-size: 10px; display: inline-flex; align-items: center; gap: 2px; color: var(--hermes-ink); }
+.context-menu-contexts-checkboxes input[type="checkbox"] { width: 12px; height: 12px; margin: 0; }
+.context-menu-mode-row { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+.context-menu-mode-select { flex-shrink: 0; font-size: 11px; }
+.context-menu-mode-row select { font-size: 11px; }
+.context-menu-prompt-input { flex: 1 1 100px; min-width: 0; font-size: 11px; }
+.context-menu-editor > button { align-self: flex-start; font-size: 11px; }

--- a/extension/app.html
+++ b/extension/app.html
@@ -287,6 +287,7 @@
               <h4>Menu items</h4>
               <div id="contextMenuItemsList" class="context-menu-items-list" role="list"></div>
               <button id="contextMenuAddItem" type="button" class="secondary">+ Add menu item</button>
+              <p id="contextMenuEditorNotice" class="context-menu-editor-notice" role="status" hidden></p>
             </div>
           </section>
           <section>

--- a/extension/app.html
+++ b/extension/app.html
@@ -283,6 +283,11 @@
               </select>
             </label>
             <p>Open Hermes Browser uses the side panel only. Selection tasks start automatically after routing.</p>
+            <div class="context-menu-editor">
+              <h4>Menu items</h4>
+              <div id="contextMenuItemsList" class="context-menu-items-list" role="list"></div>
+              <button id="contextMenuAddItem" type="button" class="secondary">+ Add menu item</button>
+            </div>
           </section>
           <section>
             <h3>Hermes connection</h3>

--- a/extension/app.js
+++ b/extension/app.js
@@ -4,7 +4,6 @@ import {
   contextMeterDisplay,
   CONTEXT_MENU_CONTEXTS,
   CONTEXT_MENU_INLINE_CONTEXTS,
-  CONTEXT_MENU_PROMPT_CONTEXTS,
   DEFAULT_SETTINGS,
   estimateTokens,
   applySessionModelBindings,
@@ -1958,11 +1957,9 @@ function renderContextMenuEditor() {
     contextsLabel.textContent = 'Show on:';
     detail.appendChild(contextsLabel);
 
-    const allowedContexts = mode === 'prompt'
-      ? CONTEXT_MENU_PROMPT_CONTEXTS
-      : mode === 'inline'
-        ? CONTEXT_MENU_INLINE_CONTEXTS
-        : CONTEXT_MENU_CONTEXTS.map((ctx) => ctx.value);
+    const allowedContexts = mode === 'inline'
+      ? CONTEXT_MENU_INLINE_CONTEXTS
+      : CONTEXT_MENU_CONTEXTS.map((ctx) => ctx.value);
 
     const contextsSelect = document.createElement('div');
     contextsSelect.className = 'context-menu-contexts-checkboxes';
@@ -2030,8 +2027,7 @@ function renderContextMenuEditor() {
         delete current.open;
         delete current.inlineAction;
         current.prompt = current.prompt || '';
-        current.contexts = current.contexts.filter((c) => CONTEXT_MENU_PROMPT_CONTEXTS.includes(c));
-        if (!current.contexts.length) current.contexts = [...CONTEXT_MENU_PROMPT_CONTEXTS];
+        if (!current.contexts.length) current.contexts = ['selection'];
       }
       persistContextMenuEditorItems();
       renderContextMenuEditor();

--- a/extension/app.js
+++ b/extension/app.js
@@ -3,7 +3,8 @@ import {
   contextCompactionState,
   contextMeterDisplay,
   CONTEXT_MENU_CONTEXTS,
-  DEFAULT_CONTEXT_MENU_ITEMS,
+  CONTEXT_MENU_INLINE_CONTEXTS,
+  CONTEXT_MENU_PROMPT_CONTEXTS,
   DEFAULT_SETTINGS,
   estimateTokens,
   applySessionModelBindings,
@@ -183,6 +184,7 @@ const els = {
   contextMenuDefaultRoute: $('#contextMenuDefaultRoute'),
   contextMenuItemsList: $('#contextMenuItemsList'),
   contextMenuAddItem: $('#contextMenuAddItem'),
+  contextMenuEditorNotice: $('#contextMenuEditorNotice'),
   settingsProfile: $('#settingsProfile'),
   settingsGatewayUrl: $('#settingsGatewayUrl'),
   settingsApiKey: $('#settingsApiKey'),
@@ -1812,15 +1814,37 @@ function initContextMenuEditorItems() {
   contextMenuEditorItems = normalizeContextMenuItems(settings.contextMenuItems).map((item) => ({ ...item }));
 }
 
+function clearContextMenuEditorNotice() {
+  if (!els.contextMenuEditorNotice) return;
+  els.contextMenuEditorNotice.hidden = true;
+  els.contextMenuEditorNotice.textContent = '';
+}
+
+function showContextMenuEditorNotice(message) {
+  if (!els.contextMenuEditorNotice) return;
+  els.contextMenuEditorNotice.textContent = message;
+  els.contextMenuEditorNotice.hidden = false;
+}
+
 function persistContextMenuEditorItems() {
-  settings = {
-    ...settings,
-    contextMenuItems: normalizeContextMenuItems(contextMenuEditorItems),
-  };
-  contextMenuEditorItems = normalizeContextMenuItems(settings.contextMenuItems).map((item) => ({ ...item }));
-  chrome.storage.local.set({ hermesBrowserSettings: settings }).catch((error) => {
-    console.warn('[Hermes Browser] Could not save context menu items:', error);
-  });
+  const previousLength = contextMenuEditorItems.length;
+  const normalized = normalizeContextMenuItems(contextMenuEditorItems);
+  contextMenuEditorItems = normalized.map((item) => ({ ...item }));
+  settings = { ...settings, contextMenuItems: normalized };
+  clearContextMenuEditorNotice();
+  chrome.storage.local.get('hermesBrowserSettings')
+    .then((stored) => {
+      const latestSettings = stored?.hermesBrowserSettings && typeof stored.hermesBrowserSettings === 'object'
+        ? stored.hermesBrowserSettings
+        : {};
+      settings = { ...settings, ...latestSettings, contextMenuItems: normalized };
+      return chrome.storage.local.set({ hermesBrowserSettings: settings });
+    })
+    .catch((error) => {
+      console.warn('[Hermes Browser] Could not save context menu items:', error);
+      showContextMenuEditorNotice(`Save failed: ${error?.message || String(error)}`);
+    });
+  if (normalized.length !== previousLength) renderContextMenuEditor();
 }
 
 function renderContextMenuEditor() {
@@ -1829,11 +1853,15 @@ function renderContextMenuEditor() {
   if (!contextMenuEditorItems.length) initContextMenuEditorItems();
   const items = contextMenuEditorItems;
   list.innerHTML = '';
-  items.forEach((item, index) => {
+  items.forEach((item) => {
     const row = document.createElement('div');
     row.className = 'context-menu-item-row';
     row.dataset.id = item.id;
     row.setAttribute('role', 'listitem');
+
+    const resolveIndex = () => contextMenuEditorItems.findIndex((candidate) => candidate.id === row.dataset.id);
+    const resolveItem = () => contextMenuEditorItems.find((candidate) => candidate.id === row.dataset.id);
+    const mode = item.open ? 'open' : item.inlineAction ? 'inline' : 'prompt';
 
     const header = document.createElement('div');
     header.className = 'context-menu-item-header';
@@ -1843,7 +1871,12 @@ function renderContextMenuEditor() {
     toggle.checked = item.enabled !== false;
     toggle.title = 'Show or hide this item';
     toggle.addEventListener('change', () => {
-      contextMenuEditorItems[index].enabled = toggle.checked;
+      const current = resolveItem();
+      if (!current) {
+        renderContextMenuEditor();
+        return;
+      }
+      current.enabled = toggle.checked;
       persistContextMenuEditorItems();
     });
     header.appendChild(toggle);
@@ -1854,7 +1887,12 @@ function renderContextMenuEditor() {
     titleInput.placeholder = 'Menu label';
     titleInput.className = 'context-menu-item-title';
     titleInput.addEventListener('change', () => {
-      contextMenuEditorItems[index].title = titleInput.value.trim();
+      const current = resolveItem();
+      if (!current) {
+        renderContextMenuEditor();
+        return;
+      }
+      current.title = titleInput.value.trim();
       persistContextMenuEditorItems();
     });
     header.appendChild(titleInput);
@@ -1866,9 +1904,10 @@ function renderContextMenuEditor() {
     upBtn.type = 'button';
     upBtn.textContent = '\u2191';
     upBtn.className = 'secondary';
-    upBtn.disabled = index === 0;
+    upBtn.disabled = resolveIndex() <= 0;
     upBtn.title = 'Move up';
     upBtn.addEventListener('click', () => {
+      const index = resolveIndex();
       if (index > 0) {
         [contextMenuEditorItems[index - 1], contextMenuEditorItems[index]] = [contextMenuEditorItems[index], contextMenuEditorItems[index - 1]];
         persistContextMenuEditorItems();
@@ -1881,10 +1920,11 @@ function renderContextMenuEditor() {
     downBtn.type = 'button';
     downBtn.textContent = '\u2193';
     downBtn.className = 'secondary';
-    downBtn.disabled = index === items.length - 1;
+    downBtn.disabled = resolveIndex() === -1 || resolveIndex() === items.length - 1;
     downBtn.title = 'Move down';
     downBtn.addEventListener('click', () => {
-      if (index < items.length - 1) {
+      const index = resolveIndex();
+      if (index >= 0 && index < items.length - 1) {
         [contextMenuEditorItems[index], contextMenuEditorItems[index + 1]] = [contextMenuEditorItems[index + 1], contextMenuEditorItems[index]];
         persistContextMenuEditorItems();
         renderContextMenuEditor();
@@ -1898,9 +1938,12 @@ function renderContextMenuEditor() {
     removeBtn.className = 'secondary';
     removeBtn.title = 'Remove item';
     removeBtn.addEventListener('click', () => {
-      contextMenuEditorItems.splice(index, 1);
-      persistContextMenuEditorItems();
-      renderContextMenuEditor();
+      const index = resolveIndex();
+      if (index >= 0) {
+        contextMenuEditorItems.splice(index, 1);
+        persistContextMenuEditorItems();
+        renderContextMenuEditor();
+      }
     });
     controls.appendChild(removeBtn);
 
@@ -1915,6 +1958,12 @@ function renderContextMenuEditor() {
     contextsLabel.textContent = 'Show on:';
     detail.appendChild(contextsLabel);
 
+    const allowedContexts = mode === 'prompt'
+      ? CONTEXT_MENU_PROMPT_CONTEXTS
+      : mode === 'inline'
+        ? CONTEXT_MENU_INLINE_CONTEXTS
+        : CONTEXT_MENU_CONTEXTS.map((ctx) => ctx.value);
+
     const contextsSelect = document.createElement('div');
     contextsSelect.className = 'context-menu-contexts-checkboxes';
     CONTEXT_MENU_CONTEXTS.forEach((ctx) => {
@@ -1922,12 +1971,17 @@ function renderContextMenuEditor() {
       const ctxCheckbox = document.createElement('input');
       ctxCheckbox.type = 'checkbox';
       ctxCheckbox.checked = item.contexts.includes(ctx.value);
+      ctxCheckbox.disabled = !allowedContexts.includes(ctx.value);
       ctxCheckbox.addEventListener('change', () => {
-        const current = contextMenuEditorItems[index].contexts;
-        if (ctxCheckbox.checked && !current.includes(ctx.value)) {
-          current.push(ctx.value);
+        const current = resolveItem();
+        if (!current) {
+          renderContextMenuEditor();
+          return;
+        }
+        if (ctxCheckbox.checked && !current.contexts.includes(ctx.value)) {
+          current.contexts.push(ctx.value);
         } else if (!ctxCheckbox.checked) {
-          contextMenuEditorItems[index].contexts = current.filter((c) => c !== ctx.value);
+          current.contexts = current.contexts.filter((c) => c !== ctx.value);
         }
         persistContextMenuEditorItems();
       });
@@ -1939,7 +1993,6 @@ function renderContextMenuEditor() {
 
     const modeRow = document.createElement('div');
     modeRow.className = 'context-menu-mode-row';
-    const isInline = Boolean(item.inlineAction);
 
     const modeSelect = document.createElement('select');
     modeSelect.className = 'context-menu-mode-select';
@@ -1949,23 +2002,48 @@ function renderContextMenuEditor() {
     const inlineOpt = document.createElement('option');
     inlineOpt.value = 'inline';
     inlineOpt.textContent = 'Inline action';
+    const openOpt = document.createElement('option');
+    openOpt.value = 'open';
+    openOpt.textContent = 'Open Hermes Browser';
     modeSelect.appendChild(promptOpt);
     modeSelect.appendChild(inlineOpt);
-    modeSelect.value = isInline ? 'inline' : 'prompt';
+    modeSelect.appendChild(openOpt);
+    modeSelect.value = mode;
     modeSelect.addEventListener('change', () => {
-      if (modeSelect.value === 'inline') {
-        delete contextMenuEditorItems[index].prompt;
-        contextMenuEditorItems[index].inlineAction = INLINE_CONTEXT_ACTIONS[0].value;
+      const current = resolveItem();
+      if (!current) {
+        renderContextMenuEditor();
+        return;
+      }
+      if (modeSelect.value === 'open') {
+        current.open = true;
+        delete current.inlineAction;
+        delete current.prompt;
+        if (!current.contexts.length) current.contexts = ['page', 'link', 'image', 'video', 'audio'];
+      } else if (modeSelect.value === 'inline') {
+        delete current.open;
+        delete current.prompt;
+        current.inlineAction = INLINE_CONTEXT_ACTIONS[0].value;
+        current.contexts = current.contexts.filter((c) => CONTEXT_MENU_INLINE_CONTEXTS.includes(c));
+        if (!current.contexts.length) current.contexts = [...CONTEXT_MENU_INLINE_CONTEXTS];
       } else {
-        delete contextMenuEditorItems[index].inlineAction;
-        contextMenuEditorItems[index].prompt = contextMenuEditorItems[index].prompt || '';
+        delete current.open;
+        delete current.inlineAction;
+        current.prompt = current.prompt || '';
+        current.contexts = current.contexts.filter((c) => CONTEXT_MENU_PROMPT_CONTEXTS.includes(c));
+        if (!current.contexts.length) current.contexts = [...CONTEXT_MENU_PROMPT_CONTEXTS];
       }
       persistContextMenuEditorItems();
       renderContextMenuEditor();
     });
     modeRow.appendChild(modeSelect);
 
-    if (isInline) {
+    if (mode === 'open') {
+      const openNote = document.createElement('span');
+      openNote.className = 'context-menu-mode-note';
+      openNote.textContent = 'Opens the Hermes side panel.';
+      modeRow.appendChild(openNote);
+    } else if (mode === 'inline') {
       const inlineSelect = document.createElement('select');
       INLINE_CONTEXT_ACTIONS.forEach((action) => {
         const opt = document.createElement('option');
@@ -1975,7 +2053,12 @@ function renderContextMenuEditor() {
       });
       inlineSelect.value = item.inlineAction;
       inlineSelect.addEventListener('change', () => {
-        contextMenuEditorItems[index].inlineAction = inlineSelect.value;
+        const current = resolveItem();
+        if (!current) {
+          renderContextMenuEditor();
+          return;
+        }
+        current.inlineAction = inlineSelect.value;
         persistContextMenuEditorItems();
       });
       modeRow.appendChild(inlineSelect);
@@ -1986,7 +2069,12 @@ function renderContextMenuEditor() {
       promptInput.placeholder = 'Prompt sent to Hermes';
       promptInput.className = 'context-menu-prompt-input';
       promptInput.addEventListener('change', () => {
-        contextMenuEditorItems[index].prompt = promptInput.value;
+        const current = resolveItem();
+        if (!current) {
+          renderContextMenuEditor();
+          return;
+        }
+        current.prompt = promptInput.value;
         persistContextMenuEditorItems();
       });
       modeRow.appendChild(promptInput);
@@ -2000,7 +2088,7 @@ function renderContextMenuEditor() {
 }
 
 function addContextMenuItem() {
-  const id = `hermes-browser-custom-${Date.now().toString(36)}`;
+  const id = `hermes-browser-custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
   contextMenuEditorItems.push({
     id,
     title: 'New action',
@@ -3083,6 +3171,21 @@ globalThis.addEventListener('visibilitychange', () => {
   if (!document.hidden) {
     consumePendingVoiceDraft().catch(() => {});
     consumePendingWakeTurn().catch(() => {});
+  }
+});
+
+chrome.storage?.onChanged?.addListener?.((changes, areaName) => {
+  if (areaName !== 'local') return;
+  const settingsChange = changes?.hermesBrowserSettings;
+  if (!settingsChange) return;
+  const next = settingsChange.newValue;
+  if (next && typeof next === 'object' && 'contextMenuItems' in next) {
+    settings = { ...settings, ...next };
+    contextMenuEditorItems = normalizeContextMenuItems(next.contextMenuItems).map((item) => ({ ...item }));
+    if (els.settingsDialog?.open && els.contextMenuItemsList) renderContextMenuEditor();
+  } else if (!next || typeof next !== 'object') {
+    contextMenuEditorItems = normalizeContextMenuItems(undefined).map((item) => ({ ...item }));
+    if (els.settingsDialog?.open && els.contextMenuItemsList) renderContextMenuEditor();
   }
 });
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -2,14 +2,19 @@ import {
   contextAccountingSnapshot,
   contextCompactionState,
   contextMeterDisplay,
+  CONTEXT_MENU_CONTEXTS,
+  DEFAULT_CONTEXT_MENU_ITEMS,
+  DEFAULT_SETTINGS,
   estimateTokens,
   applySessionModelBindings,
   groupSessionsForMenu,
+  INLINE_CONTEXT_ACTIONS,
   messageDisplayText,
   isModelRuntimeSelectable,
   normalizeHermesModels,
   normalizeHermesSessions,
   normalizeHermesSkills,
+  normalizeContextMenuItems,
   normalizeToolActivity,
   sessionModelBindingFromRuntime,
   renderMarkdown,
@@ -176,6 +181,8 @@ const els = {
   assistModelCapabilityHint: $('#assistModelCapabilityHint'),
   inlineAssistSessionRetention: $('#inlineAssistSessionRetention'),
   contextMenuDefaultRoute: $('#contextMenuDefaultRoute'),
+  contextMenuItemsList: $('#contextMenuItemsList'),
+  contextMenuAddItem: $('#contextMenuAddItem'),
   settingsProfile: $('#settingsProfile'),
   settingsGatewayUrl: $('#settingsGatewayUrl'),
   settingsApiKey: $('#settingsApiKey'),
@@ -1761,6 +1768,8 @@ function openSettings() {
   els.settingsGatewayUrl.value = settings.gatewayUrl || '';
   els.settingsApiKey.value = '';
   renderAppearanceSettings();
+  initContextMenuEditorItems();
+  renderContextMenuEditor();
   els.settingsDialog.showModal();
 }
 
@@ -1796,6 +1805,212 @@ async function saveSettings() {
   renderConnectionTruth({ status: 'idle' });
   els.settingsDialog.close();
   await loadApp();
+}
+
+let contextMenuEditorItems = [];
+
+function initContextMenuEditorItems() {
+  contextMenuEditorItems = normalizeContextMenuItems(settings.contextMenuItems).map((item) => ({ ...item }));
+}
+
+function persistContextMenuEditorItems() {
+  settings = {
+    ...settings,
+    contextMenuItems: normalizeContextMenuItems(contextMenuEditorItems),
+  };
+  contextMenuEditorItems = normalizeContextMenuItems(settings.contextMenuItems).map((item) => ({ ...item }));
+  chrome.storage.local.set({ hermesBrowserSettings: settings }).catch((error) => {
+    console.warn('[Hermes Browser] Could not save context menu items:', error);
+  });
+}
+
+function renderContextMenuEditor() {
+  const list = els.contextMenuItemsList;
+  if (!list) return;
+  if (!contextMenuEditorItems.length) initContextMenuEditorItems();
+  const items = contextMenuEditorItems;
+  list.innerHTML = '';
+  items.forEach((item, index) => {
+    const row = document.createElement('div');
+    row.className = 'context-menu-item-row';
+    row.dataset.id = item.id;
+    row.setAttribute('role', 'listitem');
+
+    const header = document.createElement('div');
+    header.className = 'context-menu-item-header';
+
+    const toggle = document.createElement('input');
+    toggle.type = 'checkbox';
+    toggle.checked = item.enabled !== false;
+    toggle.title = 'Show or hide this item';
+    toggle.addEventListener('change', () => {
+      contextMenuEditorItems[index].enabled = toggle.checked;
+      persistContextMenuEditorItems();
+    });
+    header.appendChild(toggle);
+
+    const titleInput = document.createElement('input');
+    titleInput.type = 'text';
+    titleInput.value = item.title;
+    titleInput.placeholder = 'Menu label';
+    titleInput.className = 'context-menu-item-title';
+    titleInput.addEventListener('change', () => {
+      contextMenuEditorItems[index].title = titleInput.value.trim();
+      persistContextMenuEditorItems();
+    });
+    header.appendChild(titleInput);
+
+    const controls = document.createElement('div');
+    controls.className = 'context-menu-item-controls';
+
+    const upBtn = document.createElement('button');
+    upBtn.type = 'button';
+    upBtn.textContent = '\u2191';
+    upBtn.className = 'secondary';
+    upBtn.disabled = index === 0;
+    upBtn.title = 'Move up';
+    upBtn.addEventListener('click', () => {
+      if (index > 0) {
+        [contextMenuEditorItems[index - 1], contextMenuEditorItems[index]] = [contextMenuEditorItems[index], contextMenuEditorItems[index - 1]];
+        persistContextMenuEditorItems();
+        renderContextMenuEditor();
+      }
+    });
+    controls.appendChild(upBtn);
+
+    const downBtn = document.createElement('button');
+    downBtn.type = 'button';
+    downBtn.textContent = '\u2193';
+    downBtn.className = 'secondary';
+    downBtn.disabled = index === items.length - 1;
+    downBtn.title = 'Move down';
+    downBtn.addEventListener('click', () => {
+      if (index < items.length - 1) {
+        [contextMenuEditorItems[index], contextMenuEditorItems[index + 1]] = [contextMenuEditorItems[index + 1], contextMenuEditorItems[index]];
+        persistContextMenuEditorItems();
+        renderContextMenuEditor();
+      }
+    });
+    controls.appendChild(downBtn);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '\u2715';
+    removeBtn.className = 'secondary';
+    removeBtn.title = 'Remove item';
+    removeBtn.addEventListener('click', () => {
+      contextMenuEditorItems.splice(index, 1);
+      persistContextMenuEditorItems();
+      renderContextMenuEditor();
+    });
+    controls.appendChild(removeBtn);
+
+    header.appendChild(controls);
+    row.appendChild(header);
+
+    const detail = document.createElement('div');
+    detail.className = 'context-menu-item-detail';
+
+    const contextsLabel = document.createElement('span');
+    contextsLabel.className = 'context-menu-item-label';
+    contextsLabel.textContent = 'Show on:';
+    detail.appendChild(contextsLabel);
+
+    const contextsSelect = document.createElement('div');
+    contextsSelect.className = 'context-menu-contexts-checkboxes';
+    CONTEXT_MENU_CONTEXTS.forEach((ctx) => {
+      const ctxLabel = document.createElement('label');
+      const ctxCheckbox = document.createElement('input');
+      ctxCheckbox.type = 'checkbox';
+      ctxCheckbox.checked = item.contexts.includes(ctx.value);
+      ctxCheckbox.addEventListener('change', () => {
+        const current = contextMenuEditorItems[index].contexts;
+        if (ctxCheckbox.checked && !current.includes(ctx.value)) {
+          current.push(ctx.value);
+        } else if (!ctxCheckbox.checked) {
+          contextMenuEditorItems[index].contexts = current.filter((c) => c !== ctx.value);
+        }
+        persistContextMenuEditorItems();
+      });
+      ctxLabel.appendChild(ctxCheckbox);
+      ctxLabel.append(ctx.label);
+      contextsSelect.appendChild(ctxLabel);
+    });
+    detail.appendChild(contextsSelect);
+
+    const modeRow = document.createElement('div');
+    modeRow.className = 'context-menu-mode-row';
+    const isInline = Boolean(item.inlineAction);
+
+    const modeSelect = document.createElement('select');
+    modeSelect.className = 'context-menu-mode-select';
+    const promptOpt = document.createElement('option');
+    promptOpt.value = 'prompt';
+    promptOpt.textContent = 'Send prompt';
+    const inlineOpt = document.createElement('option');
+    inlineOpt.value = 'inline';
+    inlineOpt.textContent = 'Inline action';
+    modeSelect.appendChild(promptOpt);
+    modeSelect.appendChild(inlineOpt);
+    modeSelect.value = isInline ? 'inline' : 'prompt';
+    modeSelect.addEventListener('change', () => {
+      if (modeSelect.value === 'inline') {
+        delete contextMenuEditorItems[index].prompt;
+        contextMenuEditorItems[index].inlineAction = INLINE_CONTEXT_ACTIONS[0].value;
+      } else {
+        delete contextMenuEditorItems[index].inlineAction;
+        contextMenuEditorItems[index].prompt = contextMenuEditorItems[index].prompt || '';
+      }
+      persistContextMenuEditorItems();
+      renderContextMenuEditor();
+    });
+    modeRow.appendChild(modeSelect);
+
+    if (isInline) {
+      const inlineSelect = document.createElement('select');
+      INLINE_CONTEXT_ACTIONS.forEach((action) => {
+        const opt = document.createElement('option');
+        opt.value = action.value;
+        opt.textContent = action.label;
+        inlineSelect.appendChild(opt);
+      });
+      inlineSelect.value = item.inlineAction;
+      inlineSelect.addEventListener('change', () => {
+        contextMenuEditorItems[index].inlineAction = inlineSelect.value;
+        persistContextMenuEditorItems();
+      });
+      modeRow.appendChild(inlineSelect);
+    } else {
+      const promptInput = document.createElement('input');
+      promptInput.type = 'text';
+      promptInput.value = item.prompt || '';
+      promptInput.placeholder = 'Prompt sent to Hermes';
+      promptInput.className = 'context-menu-prompt-input';
+      promptInput.addEventListener('change', () => {
+        contextMenuEditorItems[index].prompt = promptInput.value;
+        persistContextMenuEditorItems();
+      });
+      modeRow.appendChild(promptInput);
+    }
+
+    detail.appendChild(modeRow);
+    row.appendChild(detail);
+
+    list.appendChild(row);
+  });
+}
+
+function addContextMenuItem() {
+  const id = `hermes-browser-custom-${Date.now().toString(36)}`;
+  contextMenuEditorItems.push({
+    id,
+    title: 'New action',
+    contexts: ['selection'],
+    prompt: '',
+    enabled: true,
+  });
+  persistContextMenuEditorItems();
+  renderContextMenuEditor();
 }
 
 function formatBytes(value = 0) {
@@ -2739,6 +2954,9 @@ els.settingsThemeGrid.addEventListener('click', (event) => {
 els.settingsForm.addEventListener('submit', (event) => {
   event.preventDefault();
   saveSettings().catch((error) => { els.composerStatus.textContent = `Settings failed: ${error?.message || String(error)}`; });
+});
+els.contextMenuAddItem?.addEventListener('click', () => {
+  addContextMenuItem();
 });
 els.newChatButton.addEventListener('click', () => beginHermesWebDraft().catch((error) => showError('Could not start draft', error?.message || String(error))));
 els.modelPickerButton.addEventListener('click', () => {

--- a/extension/background.js
+++ b/extension/background.js
@@ -440,6 +440,13 @@ function openSidePanelWithinUserGesture(tab) {
 }
 
 async function handleContextMenuClick(info, tab) {
+  // Hydrate cache from storage on cold wake — storage read is safe before the gesture call
+  try {
+    const stored = await chrome.storage.local.get('hermesBrowserSettings');
+    cachedContextMenuItems = normalizeContextMenuItems(stored?.hermesBrowserSettings?.contextMenuItems);
+  } catch {
+    // Fall back to existing cache if storage is unavailable
+  }
   const item = cachedContextMenuItems.find((candidate) => candidate.id === info?.menuItemId);
   if (!item || !tab?.id) return;
   if (item.inlineAction) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -32,13 +32,14 @@ import {
 import { createWakeBackgroundController } from './lib/wake-background.mjs';
 import { WAKE_MESSAGES } from './lib/wake-word.mjs';
 import {
-  DEFAULT_CONTEXT_MENU_ITEMS,
+  cloneDefaultContextMenuItems,
   normalizeContextMenuItems,
 } from './lib/common.mjs';
 
 let cachedPanelResidencyMode = DEFAULT_PANEL_RESIDENCY_MODE;
 let contextMenuConfigurationPromise = null;
-let cachedContextMenuItems = DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({ ...item }));
+let contextMenuRebuildChain = Promise.resolve();
+let cachedContextMenuItems = cloneDefaultContextMenuItems();
 const INLINE_DRAFT_STORAGE_KEY = 'hermesBrowserInlineDraftRequest';
 const INLINE_SESSION_STATE_KEY = 'hermesBrowserInlineSessionState';
 const CONTEXT_MENU_STORAGE_KEY = 'hermesBrowserContextMenuRequest';
@@ -46,6 +47,7 @@ const OPEN_SESSION_STORAGE_KEY = 'hermesBrowserOpenSessionRequest';
 const INLINE_DRAFT_TTL_MS = 5 * 60 * 1000;
 const HERMES_ASSIST_SOURCE = 'hermes_assist';
 const CONTEXT_MENU_ROOT_ID = 'hermes-browser-root';
+const CONTEXT_MENU_ALL_CONTEXTS = ['page', 'selection', 'editable', 'link', 'image', 'video', 'audio'];
 const WAKE_BACKGROUND_MESSAGE_TYPES = new Set([
   WAKE_MESSAGES.claimTurn,
   WAKE_MESSAGES.getState,
@@ -334,23 +336,32 @@ async function configureContextMenus() {
 
   const configuration = (async () => {
     const stored = await chrome.storage.local.get('hermesBrowserSettings');
-    cachedContextMenuItems = normalizeContextMenuItems(stored?.hermesBrowserSettings?.contextMenuItems);
-    await chrome.contextMenus.removeAll();
-    const allContexts = ['page', 'selection', 'editable', 'link', 'image', 'video', 'audio'];
-    await createContextMenu({
-      id: CONTEXT_MENU_ROOT_ID,
-      title: 'Hermes Browser',
-      contexts: allContexts,
-    });
-    for (const item of cachedContextMenuItems) {
-      if (item.enabled === false) continue;
+    const nextItems = normalizeContextMenuItems(stored?.hermesBrowserSettings?.contextMenuItems);
+    let menuMutated = false;
+    try {
+      await chrome.contextMenus.removeAll();
+      menuMutated = true;
       await createContextMenu({
-        id: item.id,
-        parentId: CONTEXT_MENU_ROOT_ID,
-        title: item.title,
-        contexts: item.contexts,
+        id: CONTEXT_MENU_ROOT_ID,
+        title: 'Hermes Browser',
+        contexts: CONTEXT_MENU_ALL_CONTEXTS,
       });
+      for (const item of nextItems) {
+        if (item.enabled === false) continue;
+        await createContextMenu({
+          id: item.id,
+          parentId: CONTEXT_MENU_ROOT_ID,
+          title: item.title,
+          contexts: item.contexts,
+        });
+      }
+    } catch (error) {
+      if (menuMutated && cachedContextMenuItems.length) {
+        await restoreLastGoodContextMenu().catch(() => null);
+      }
+      throw error;
     }
+    cachedContextMenuItems = nextItems;
   })();
   contextMenuConfigurationPromise = configuration;
 
@@ -361,9 +372,33 @@ async function configureContextMenus() {
   }
 }
 
-async function rebuildContextMenus() {
-  contextMenuConfigurationPromise = null;
-  await configureContextMenus();
+async function restoreLastGoodContextMenu() {
+  await chrome.contextMenus.removeAll();
+  await createContextMenu({
+    id: CONTEXT_MENU_ROOT_ID,
+    title: 'Hermes Browser',
+    contexts: CONTEXT_MENU_ALL_CONTEXTS,
+  });
+  for (const item of cachedContextMenuItems) {
+    if (item.enabled === false) continue;
+    await createContextMenu({
+      id: item.id,
+      parentId: CONTEXT_MENU_ROOT_ID,
+      title: item.title,
+      contexts: item.contexts,
+    });
+  }
+}
+
+function rebuildContextMenus() {
+  contextMenuRebuildChain = contextMenuRebuildChain
+    .catch(() => null)
+    .then(async () => {
+      const inFlight = contextMenuConfigurationPromise;
+      if (inFlight) await inFlight.catch(() => null);
+      return configureContextMenus();
+    });
+  return contextMenuRebuildChain;
 }
 
 function safeContextPageUrl(value = '') {
@@ -381,7 +416,7 @@ function safeContextPageUrl(value = '') {
 async function handleContextMenuClick(info, tab) {
   const item = cachedContextMenuItems.find((candidate) => candidate.id === info?.menuItemId);
   if (!item || !tab?.id) return;
-  if (item.id === 'hermes-browser-open') {
+  if (item.open) {
     await openHermesPanel(tab, { allowFallback: false });
     return;
   }
@@ -764,7 +799,8 @@ chrome.storage?.onChanged?.addListener?.((changes, areaName) => {
     cachedPanelResidencyMode = normalizePanelResidencyMode(changes.panelResidencyMode.newValue);
     changed = true;
   }
-  if (changes.hermesBrowserSettings?.newValue?.contextMenuItems) {
+  const settingsChange = changes.hermesBrowserSettings;
+  if (settingsChange && ('contextMenuItems' in (settingsChange.newValue || {}) || 'contextMenuItems' in (settingsChange.oldValue || {}))) {
     rebuildContextMenus().catch((error) => console.warn('[Hermes Browser] Context menu rebuild failed:', error));
   }
   if (changed) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -417,7 +417,7 @@ async function handleContextMenuClick(info, tab) {
   const item = cachedContextMenuItems.find((candidate) => candidate.id === info?.menuItemId);
   if (!item || !tab?.id) return;
   if (item.open) {
-    await openHermesPanel(tab, { allowFallback: true });
+    await openHermesPanel(tab, { allowFallback: true, lenientPanel: true });
     return;
   }
   if (item.inlineAction) {
@@ -439,7 +439,7 @@ async function handleContextMenuClick(info, tab) {
       expiresAt: Date.now() + INLINE_DRAFT_TTL_MS,
     },
   });
-  await openHermesPanel(tab, { allowFallback: true });
+  await openHermesPanel(tab, { allowFallback: true, lenientPanel: true });
 }
 
 async function configureInstalledSurfaces() {
@@ -583,7 +583,7 @@ async function openOrFocusPanelTab(panelUrl) {
   }
 }
 
-async function openHermesPanel(tab, { allowFallback = true } = {}) {
+async function openHermesPanel(tab, { allowFallback = true, lenientPanel = false } = {}) {
   await refreshPanelResidencyModeFromStorage();
   const panelResidencyMode = cachedPanelResidencyMode;
   const tabId = Number(tab?.id);
@@ -615,6 +615,7 @@ async function openHermesPanel(tab, { allowFallback = true } = {}) {
             runtimeApi: chrome.runtime,
             openOptions: { tabId },
             panelUrl,
+            requireConfirmation: !lenientPanel,
           });
           if (panelOpened) return;
         } catch (tabOpenError) {
@@ -627,6 +628,7 @@ async function openHermesPanel(tab, { allowFallback = true } = {}) {
             runtimeApi: chrome.runtime,
             openOptions: { windowId },
             panelUrl,
+            requireConfirmation: !lenientPanel,
           });
           if (panelOpened) return;
         }
@@ -638,6 +640,7 @@ async function openHermesPanel(tab, { allowFallback = true } = {}) {
           runtimeApi: chrome.runtime,
           openOptions: { windowId },
           panelUrl,
+          requireConfirmation: !lenientPanel,
         });
         if (panelOpened) return;
       }
@@ -785,9 +788,9 @@ chrome.runtime.onStartup.addListener(async () => {
   restoreWakeController();
 });
 chrome.action.onClicked.addListener(openHermesPanel);
-chrome.contextMenus?.onClicked?.addListener?.((info, tab) => {
-  handleContextMenuClick(info, tab).catch((error) => console.warn('[Hermes Browser] Context menu action failed:', error));
-});
+chrome.contextMenus?.onClicked?.addListener?.((info, tab) => (
+  handleContextMenuClick(info, tab).catch((error) => console.warn('[Hermes Browser] Context menu action failed:', error))
+));
 chrome.tabs?.onActivated?.addListener?.(({ tabId }) => reapplyPanelResidencyForTab(tabId));
 chrome.storage?.onChanged?.addListener?.((changes, areaName) => {
   if (areaName !== 'local') return;

--- a/extension/background.js
+++ b/extension/background.js
@@ -413,15 +413,51 @@ function safeContextPageUrl(value = '') {
   }
 }
 
+function openSidePanelWithinUserGesture(tab) {
+  // chrome.sidePanel.open() may only be called in response to a user gesture,
+  // and the gesture is forfeited as soon as the handler awaits any chrome API
+  // call. The async openHermesPanel path alone therefore always fails the
+  // gesture check and opens a fallback tab instead. Attempt the open
+  // synchronously here, inside the click's live gesture; the async path only
+  // runs when the panel is not yet enabled for this tab/window.
+  const sidePanelApi = chrome?.sidePanel;
+  if (typeof sidePanelApi?.open !== 'function') return { attempted: false };
+  const tabId = Number(tab?.id);
+  const windowId = Number(tab?.windowId);
+  const tabAttached = normalizePanelResidencyMode(cachedPanelResidencyMode) === PANEL_RESIDENCY_MODES.TAB_ATTACHED;
+  let openOptions = null;
+  if (tabAttached && Number.isFinite(tabId) && tabId > 0) {
+    openOptions = { tabId };
+  } else if (Number.isFinite(windowId)) {
+    openOptions = { windowId };
+  }
+  if (!openOptions) return { attempted: false };
+  try {
+    return { attempted: true, openPromise: Promise.resolve(sidePanelApi.open(openOptions)) };
+  } catch (error) {
+    return { attempted: true, openPromise: Promise.reject(error) };
+  }
+}
+
 async function handleContextMenuClick(info, tab) {
   const item = cachedContextMenuItems.find((candidate) => candidate.id === info?.menuItemId);
   if (!item || !tab?.id) return;
-  if (item.open) {
-    await openHermesPanel(tab, { allowFallback: true, lenientPanel: true });
-    return;
-  }
   if (item.inlineAction) {
     await chrome.tabs.sendMessage(tab.id, { type: 'HERMES_INLINE_CONTEXT_ACTION', actionId: item.inlineAction }).catch(() => null);
+    return;
+  }
+
+  // Summon the panel inside the user gesture (see openSidePanelWithinUserGesture).
+  // If the panel is not yet enabled for this tab/window the promise rejects
+  // and we run the async openHermesPanel path instead: re-apply residency,
+  // retry the open, and only then fall back to a tab.
+  const gestureOpen = openSidePanelWithinUserGesture(tab);
+  const summonPanel = gestureOpen.attempted
+    ? gestureOpen.openPromise.catch(() => openHermesPanel(tab, { allowFallback: true, lenientPanel: true }))
+    : openHermesPanel(tab, { allowFallback: true, lenientPanel: true });
+
+  if (item.open) {
+    await summonPanel;
     return;
   }
   const selection = String(info?.selectionText || '').trim().slice(0, 8_000);
@@ -439,7 +475,9 @@ async function handleContextMenuClick(info, tab) {
       expiresAt: Date.now() + INLINE_DRAFT_TTL_MS,
     },
   });
-  await openHermesPanel(tab, { allowFallback: true, lenientPanel: true });
+  // The panel summoned above consumes the request on load (fresh panel) or
+  // via storage.onChanged (panel already open).
+  await summonPanel;
 }
 
 async function configureInstalledSurfaces() {

--- a/extension/background.js
+++ b/extension/background.js
@@ -417,7 +417,7 @@ async function handleContextMenuClick(info, tab) {
   const item = cachedContextMenuItems.find((candidate) => candidate.id === info?.menuItemId);
   if (!item || !tab?.id) return;
   if (item.open) {
-    await openHermesPanel(tab, { allowFallback: false });
+    await openHermesPanel(tab, { allowFallback: true });
     return;
   }
   if (item.inlineAction) {
@@ -425,7 +425,7 @@ async function handleContextMenuClick(info, tab) {
     return;
   }
   const selection = String(info?.selectionText || '').trim().slice(0, 8_000);
-  if (!selection || !chrome.storage?.session) return;
+  if (!chrome.storage?.session) return;
   const stored = await chrome.storage.local.get('hermesBrowserSettings');
   const route = normalizeContextMenuRoute(stored?.hermesBrowserSettings?.contextMenuDefaultRoute);
   await chrome.storage.session.set({
@@ -439,7 +439,7 @@ async function handleContextMenuClick(info, tab) {
       expiresAt: Date.now() + INLINE_DRAFT_TTL_MS,
     },
   });
-  await openHermesPanel(tab, { allowFallback: false });
+  await openHermesPanel(tab, { allowFallback: true });
 }
 
 async function configureInstalledSurfaces() {

--- a/extension/background.js
+++ b/extension/background.js
@@ -31,9 +31,14 @@ import {
 } from './lib/assist-model-contract.mjs';
 import { createWakeBackgroundController } from './lib/wake-background.mjs';
 import { WAKE_MESSAGES } from './lib/wake-word.mjs';
+import {
+  DEFAULT_CONTEXT_MENU_ITEMS,
+  normalizeContextMenuItems,
+} from './lib/common.mjs';
 
 let cachedPanelResidencyMode = DEFAULT_PANEL_RESIDENCY_MODE;
 let contextMenuConfigurationPromise = null;
+let cachedContextMenuItems = DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({ ...item }));
 const INLINE_DRAFT_STORAGE_KEY = 'hermesBrowserInlineDraftRequest';
 const INLINE_SESSION_STATE_KEY = 'hermesBrowserInlineSessionState';
 const CONTEXT_MENU_STORAGE_KEY = 'hermesBrowserContextMenuRequest';
@@ -41,14 +46,6 @@ const OPEN_SESSION_STORAGE_KEY = 'hermesBrowserOpenSessionRequest';
 const INLINE_DRAFT_TTL_MS = 5 * 60 * 1000;
 const HERMES_ASSIST_SOURCE = 'hermes_assist';
 const CONTEXT_MENU_ROOT_ID = 'hermes-browser-root';
-const CONTEXT_MENU_ITEMS = Object.freeze([
-  { id: 'hermes-browser-ask-selection', title: 'Ask Hermes about this selection', contexts: ['selection'], prompt: 'Help me understand or work with this selected text:' },
-  { id: 'hermes-browser-summarize-selection', title: 'Summarize selection', contexts: ['selection'], prompt: 'Summarize this selected text concisely:' },
-  { id: 'hermes-browser-explain-selection', title: 'Explain selection', contexts: ['selection'], prompt: 'Explain this selected text clearly:' },
-  { id: 'hermes-browser-improve-editable', title: 'Improve selected text', contexts: ['editable'], inlineAction: 'improve' },
-  { id: 'hermes-browser-draft-reply', title: 'Draft reply with Hermes', contexts: ['editable'], inlineAction: 'draft-reply' },
-  { id: 'hermes-browser-open', title: 'Open Hermes Browser', contexts: ['page', 'link', 'image', 'video', 'audio'] },
-]);
 const WAKE_BACKGROUND_MESSAGE_TYPES = new Set([
   WAKE_MESSAGES.claimTurn,
   WAKE_MESSAGES.getState,
@@ -336,13 +333,17 @@ async function configureContextMenus() {
   if (contextMenuConfigurationPromise) return contextMenuConfigurationPromise;
 
   const configuration = (async () => {
+    const stored = await chrome.storage.local.get('hermesBrowserSettings');
+    cachedContextMenuItems = normalizeContextMenuItems(stored?.hermesBrowserSettings?.contextMenuItems);
     await chrome.contextMenus.removeAll();
+    const allContexts = ['page', 'selection', 'editable', 'link', 'image', 'video', 'audio'];
     await createContextMenu({
       id: CONTEXT_MENU_ROOT_ID,
       title: 'Hermes Browser',
-      contexts: ['page', 'selection', 'editable', 'link', 'image', 'video', 'audio'],
+      contexts: allContexts,
     });
-    for (const item of CONTEXT_MENU_ITEMS) {
+    for (const item of cachedContextMenuItems) {
+      if (item.enabled === false) continue;
       await createContextMenu({
         id: item.id,
         parentId: CONTEXT_MENU_ROOT_ID,
@@ -360,6 +361,11 @@ async function configureContextMenus() {
   }
 }
 
+async function rebuildContextMenus() {
+  contextMenuConfigurationPromise = null;
+  await configureContextMenus();
+}
+
 function safeContextPageUrl(value = '') {
   try {
     const url = new URL(String(value || ''));
@@ -373,7 +379,7 @@ function safeContextPageUrl(value = '') {
 }
 
 async function handleContextMenuClick(info, tab) {
-  const item = CONTEXT_MENU_ITEMS.find((candidate) => candidate.id === info?.menuItemId);
+  const item = cachedContextMenuItems.find((candidate) => candidate.id === info?.menuItemId);
   if (!item || !tab?.id) return;
   if (item.id === 'hermes-browser-open') {
     await openHermesPanel(tab, { allowFallback: false });
@@ -757,6 +763,9 @@ chrome.storage?.onChanged?.addListener?.((changes, areaName) => {
   } else if (changes.panelResidencyMode?.newValue) {
     cachedPanelResidencyMode = normalizePanelResidencyMode(changes.panelResidencyMode.newValue);
     changed = true;
+  }
+  if (changes.hermesBrowserSettings?.newValue?.contextMenuItems) {
+    rebuildContextMenus().catch((error) => console.warn('[Hermes Browser] Context menu rebuild failed:', error));
   }
   if (changed) {
     activeBrowserTabId()

--- a/extension/lib/browser-runtime.mjs
+++ b/extension/lib/browser-runtime.mjs
@@ -184,6 +184,7 @@ async function openSidePanelWithConfirmation({
   pollDelays = [0, 75, 150, 300, 500],
   userAgent = globalThis.navigator?.userAgent || '',
   wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  requireConfirmation = true,
 } = {}) {
   if (typeof sidePanelApi?.open !== 'function') return false;
 
@@ -200,6 +201,10 @@ async function openSidePanelWithConfirmation({
 
   try {
     await sidePanelApi.open(openOptions);
+    // For user-initiated right-click actions an answered open() call is
+    // enough: some Chrome versions resolve the panel without a confirming
+    // onOpened event, and a fallback tab is worse than a settled panel.
+    if (!requireConfirmation) return true;
     for (const delay of pollDelays) {
       if (delay > 0) await wait(delay);
       if (openedByEvent) return true;

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -70,7 +70,6 @@ export const CONTEXT_MENU_OPEN_ID = 'hermes-browser-open';
 export const CONTEXT_MENU_MAX_ITEMS = 20;
 export const CONTEXT_MENU_MAX_TITLE_LENGTH = 64;
 export const CONTEXT_MENU_MAX_PROMPT_LENGTH = 8_000;
-export const CONTEXT_MENU_PROMPT_CONTEXTS = Object.freeze(['selection', 'editable']);
 export const CONTEXT_MENU_INLINE_CONTEXTS = Object.freeze(['editable']);
 
 export const DEFAULT_CONTEXT_MENU_ITEMS = Object.freeze([
@@ -129,8 +128,9 @@ export function normalizeContextMenuItem(value) {
     return null;
   } else {
     item.prompt = String(value.prompt || '').trim().slice(0, CONTEXT_MENU_MAX_PROMPT_LENGTH);
-    item.contexts = restrictContexts(contexts, CONTEXT_MENU_PROMPT_CONTEXTS);
-    if (!item.contexts.length) return null;
+    // Prompt items work on every context: selection/editable pass the selected
+    // text, and page/link/image/video/audio hand the prompt and page URL to the
+    // panel without a selection.
   }
   return item;
 }

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -47,6 +47,63 @@ export const TEXT_SIZE_OPTIONS = Object.freeze([
   { value: 'extra-large', label: 'Extra large' },
 ]);
 
+export const INLINE_CONTEXT_ACTIONS = Object.freeze([
+  { value: 'improve', label: 'Improve writing' },
+  { value: 'draft-reply', label: 'Draft reply' },
+  { value: 'shorten', label: 'Shorten' },
+  { value: 'fix-grammar', label: 'Fix grammar' },
+  { value: 'change-tone', label: 'Change tone' },
+  { value: 'draft-for-context', label: 'Draft for this field' },
+]);
+
+export const CONTEXT_MENU_CONTEXTS = Object.freeze([
+  { value: 'selection', label: 'Selected text' },
+  { value: 'editable', label: 'Editable fields' },
+  { value: 'page', label: 'Page' },
+  { value: 'link', label: 'Links' },
+  { value: 'image', label: 'Images' },
+  { value: 'video', label: 'Videos' },
+  { value: 'audio', label: 'Audio' },
+]);
+
+export const DEFAULT_CONTEXT_MENU_ITEMS = Object.freeze([
+  { id: 'hermes-browser-ask-selection', title: 'Ask Hermes about this selection', contexts: ['selection'], prompt: 'Help me understand or work with this selected text:', enabled: true },
+  { id: 'hermes-browser-summarize-selection', title: 'Summarize selection', contexts: ['selection'], prompt: 'Summarize this selected text concisely:', enabled: true },
+  { id: 'hermes-browser-explain-selection', title: 'Explain selection', contexts: ['selection'], prompt: 'Explain this selected text clearly:', enabled: true },
+  { id: 'hermes-browser-improve-editable', title: 'Improve selected text', contexts: ['editable'], inlineAction: 'improve', enabled: true },
+  { id: 'hermes-browser-draft-reply', title: 'Draft reply with Hermes', contexts: ['editable'], inlineAction: 'draft-reply', enabled: true },
+  { id: 'hermes-browser-open', title: 'Open Hermes Browser', contexts: ['page', 'link', 'image', 'video', 'audio'], enabled: true },
+]);
+
+export function normalizeContextMenuItem(value) {
+  if (!value || typeof value !== 'object') return null;
+  const id = String(value.id || '').trim();
+  if (!id) return null;
+  const title = String(value.title || '').trim();
+  if (!title) return null;
+  const validContexts = Array.isArray(value.contexts)
+    ? value.contexts.filter((c) => CONTEXT_MENU_CONTEXTS.some((ctx) => ctx.value === c))
+    : [];
+  if (!validContexts.length) return null;
+  const item = { id, title, contexts: validContexts, enabled: value.enabled !== false };
+  if (value.inlineAction) {
+    item.inlineAction = String(value.inlineAction);
+  } else if (value.prompt) {
+    item.prompt = String(value.prompt).trim();
+  } else {
+    item.prompt = '';
+  }
+  return item;
+}
+
+export function normalizeContextMenuItems(items) {
+  if (!Array.isArray(items)) return DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({ ...item }));
+  const normalized = items
+    .map((item) => normalizeContextMenuItem(item))
+    .filter(Boolean);
+  return normalized.length ? normalized : DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({ ...item }));
+}
+
 export const DEFAULT_SETTINGS = Object.freeze({
   connectionSchemaVersion: CONNECTION_SCHEMA_VERSION,
   connectionMode: 'local',
@@ -90,6 +147,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   inlineAssistReasoningEffort: 'low',
   inlineAssistFastMode: false,
   contextMenuDefaultRoute: 'ask',
+  contextMenuItems: Object.freeze(DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({ ...item }))),
   transcriptProvider: 'default',
   wakeWordEnabled: false,
   wakeWordPhrase: 'hey hermes',

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -66,6 +66,13 @@ export const CONTEXT_MENU_CONTEXTS = Object.freeze([
   { value: 'audio', label: 'Audio' },
 ]);
 
+export const CONTEXT_MENU_OPEN_ID = 'hermes-browser-open';
+export const CONTEXT_MENU_MAX_ITEMS = 20;
+export const CONTEXT_MENU_MAX_TITLE_LENGTH = 64;
+export const CONTEXT_MENU_MAX_PROMPT_LENGTH = 8_000;
+export const CONTEXT_MENU_PROMPT_CONTEXTS = Object.freeze(['selection', 'editable']);
+export const CONTEXT_MENU_INLINE_CONTEXTS = Object.freeze(['editable']);
+
 export const DEFAULT_CONTEXT_MENU_ITEMS = Object.freeze([
   { id: 'hermes-browser-ask-selection', title: 'Ask Hermes about this selection', contexts: ['selection'], prompt: 'Help me understand or work with this selected text:', enabled: true },
   { id: 'hermes-browser-summarize-selection', title: 'Summarize selection', contexts: ['selection'], prompt: 'Summarize this selected text concisely:', enabled: true },
@@ -75,33 +82,71 @@ export const DEFAULT_CONTEXT_MENU_ITEMS = Object.freeze([
   { id: 'hermes-browser-open', title: 'Open Hermes Browser', contexts: ['page', 'link', 'image', 'video', 'audio'], enabled: true },
 ]);
 
+export function cloneDefaultContextMenuItems() {
+  return DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({
+    ...item,
+    contexts: [...item.contexts],
+  }));
+}
+
+function validContextValues(contexts) {
+  if (!Array.isArray(contexts)) return [];
+  const allowed = new Set(CONTEXT_MENU_CONTEXTS.map((ctx) => ctx.value));
+  const seen = new Set();
+  const result = [];
+  for (const context of contexts) {
+    const value = String(context);
+    if (!allowed.has(value) || seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function restrictContexts(contexts, allowed) {
+  const allowedSet = new Set(allowed);
+  return contexts.filter((context) => allowedSet.has(context));
+}
+
 export function normalizeContextMenuItem(value) {
   if (!value || typeof value !== 'object') return null;
   const id = String(value.id || '').trim();
   if (!id) return null;
-  const title = String(value.title || '').trim();
+  const title = String(value.title || '').trim().slice(0, CONTEXT_MENU_MAX_TITLE_LENGTH);
   if (!title) return null;
-  const validContexts = Array.isArray(value.contexts)
-    ? value.contexts.filter((c) => CONTEXT_MENU_CONTEXTS.some((ctx) => ctx.value === c))
-    : [];
-  if (!validContexts.length) return null;
-  const item = { id, title, contexts: validContexts, enabled: value.enabled !== false };
-  if (value.inlineAction) {
-    item.inlineAction = String(value.inlineAction);
-  } else if (value.prompt) {
-    item.prompt = String(value.prompt).trim();
+  const contexts = validContextValues(value.contexts);
+  if (!contexts.length) return null;
+  const item = { id, title, contexts, enabled: value.enabled !== false };
+  const isOpen = value.open === true || value.mode === 'open' || id === CONTEXT_MENU_OPEN_ID;
+  if (isOpen) {
+    item.open = true;
+  } else if (value.inlineAction && INLINE_CONTEXT_ACTIONS.some((action) => action.value === value.inlineAction)) {
+    item.inlineAction = value.inlineAction;
+    item.contexts = restrictContexts(contexts, CONTEXT_MENU_INLINE_CONTEXTS);
+    if (!item.contexts.length) return null;
+  } else if (value.inlineAction) {
+    // Unknown inline action: reject the item rather than advertising a silent no-op.
+    return null;
   } else {
-    item.prompt = '';
+    item.prompt = String(value.prompt || '').trim().slice(0, CONTEXT_MENU_MAX_PROMPT_LENGTH);
+    item.contexts = restrictContexts(contexts, CONTEXT_MENU_PROMPT_CONTEXTS);
+    if (!item.contexts.length) return null;
   }
   return item;
 }
 
 export function normalizeContextMenuItems(items) {
-  if (!Array.isArray(items)) return DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({ ...item }));
-  const normalized = items
-    .map((item) => normalizeContextMenuItem(item))
-    .filter(Boolean);
-  return normalized.length ? normalized : DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({ ...item }));
+  if (!Array.isArray(items)) return cloneDefaultContextMenuItems();
+  const seenIds = new Set();
+  const normalized = [];
+  for (const value of items) {
+    if (normalized.length >= CONTEXT_MENU_MAX_ITEMS) break;
+    const item = normalizeContextMenuItem(value);
+    if (!item || seenIds.has(item.id)) continue;
+    seenIds.add(item.id);
+    normalized.push(item);
+  }
+  return normalized;
 }
 
 export const DEFAULT_SETTINGS = Object.freeze({
@@ -147,7 +192,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   inlineAssistReasoningEffort: 'low',
   inlineAssistFastMode: false,
   contextMenuDefaultRoute: 'ask',
-  contextMenuItems: Object.freeze(DEFAULT_CONTEXT_MENU_ITEMS.map((item) => ({ ...item }))),
+  contextMenuItems: Object.freeze(cloneDefaultContextMenuItems()),
   transcriptProvider: 'default',
   wakeWordEnabled: false,
   wakeWordPhrase: 'hey hermes',

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -4246,5 +4246,7 @@ html[data-hermes-text-size] .message-content h6 { font-size: calc(13px * var(--h
 .context-menu-mode-row { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
 .context-menu-mode-select { flex-shrink: 0; font-size: 11px; }
 .context-menu-mode-row select { font-size: 11px; }
+.context-menu-mode-note { font-size: 10px; color: var(--hermes-muted); }
+.context-menu-editor-notice { font-size: 11px; color: var(--hermes-danger, #b3261e); margin: 0; }
 .context-menu-prompt-input { flex: 1 1 100px; min-width: 0; font-size: 11px; }
 .context-menu-editor > button { align-self: flex-start; font-size: 11px; }

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -4228,3 +4228,23 @@ html[data-hermes-text-size] .message-content h6 { font-size: calc(13px * var(--h
   .task-stack-progress i,
   .task-stack-chevron { transition: none; }
 }
+
+.context-menu-editor { margin-top: 12px; display: flex; flex-direction: column; gap: 8px; }
+.context-menu-editor h4 { margin: 0; font-size: 10px; font-weight: 600; color: var(--hermes-muted); text-transform: uppercase; letter-spacing: 0.15em; }
+.context-menu-items-list { display: flex; flex-direction: column; gap: 6px; }
+.context-menu-item-row { border: 1px solid var(--hermes-line); border-radius: var(--radius, 4px); padding: 8px; display: flex; flex-direction: column; gap: 6px; background: rgba(var(--hermes-ink-rgb), 0.035); }
+.context-menu-item-header { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; }
+.context-menu-item-header input[type="checkbox"] { margin: 0; flex-shrink: 0; width: 14px; height: 14px; }
+.context-menu-item-title { flex: 1 1 120px; min-width: 0; font-size: 12px; }
+.context-menu-item-controls { display: flex; gap: 2px; flex-shrink: 0; }
+.context-menu-item-controls button { padding: 2px 5px; font-size: 11px; min-width: 22px; line-height: 1.4; }
+.context-menu-item-detail { display: flex; flex-direction: column; gap: 4px; padding-left: 18px; }
+.context-menu-item-label { font-size: 9px; font-weight: 500; color: var(--hermes-muted); text-transform: uppercase; letter-spacing: 0.12em; }
+.context-menu-contexts-checkboxes { display: flex; flex-wrap: wrap; gap: 4px 6px; }
+.context-menu-contexts-checkboxes label { font-size: 10px; display: inline-flex; align-items: center; gap: 2px; color: var(--hermes-ink); }
+.context-menu-contexts-checkboxes input[type="checkbox"] { width: 12px; height: 12px; margin: 0; }
+.context-menu-mode-row { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+.context-menu-mode-select { flex-shrink: 0; font-size: 11px; }
+.context-menu-mode-row select { font-size: 11px; }
+.context-menu-prompt-input { flex: 1 1 100px; min-width: 0; font-size: 11px; }
+.context-menu-editor > button { align-self: flex-start; font-size: 11px; }

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -467,6 +467,7 @@
             <h4>Menu items</h4>
             <div id="contextMenuItemsList" class="context-menu-items-list" role="list"></div>
             <button id="contextMenuAddItem" type="button" class="secondary">+ Add menu item</button>
+            <p id="contextMenuEditorNotice" class="context-menu-editor-notice" role="status" hidden></p>
           </div>
         </section>
 

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -463,6 +463,11 @@
             </select>
           </label>
           <p class="hint">Open Hermes Browser always opens the side panel only. Selection actions start immediately after routing.</p>
+          <div class="context-menu-editor">
+            <h4>Menu items</h4>
+            <div id="contextMenuItemsList" class="context-menu-items-list" role="list"></div>
+            <button id="contextMenuAddItem" type="button" class="secondary">+ Add menu item</button>
+          </div>
         </section>
 
         <section class="settings-section connection-settings" aria-labelledby="connectionTitle">

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -8306,14 +8306,37 @@ function contextMenuPromptText(request = {}) {
   return text;
 }
 
+async function contextMenuPageText(request = {}) {
+  // Page-level prompt items carry only the page URL (background.js writes
+  // selection: '' for page contexts). Capture the actual page content so the
+  // task can work with the page itself — selection items already carry their
+  // content and skip capture. Depth honors the control-panel setting
+  // (contextDepth: minimal / normal / full). Failure degrades to URL-only,
+  // never drops the request.
+  if (!request.pageUrl || request.selection || !Number.isFinite(request.tabId)) return '';
+  const tab = await chrome.tabs.get(request.tabId).catch(() => null);
+  if (!tab) return '';
+  const pageContext = await getPageContext(tab, {});
+  if (!pageContext?.ok || !pageContext.text) return '';
+  return pageContext.text;
+}
+
 async function executeContextMenuRequest(request, requestedRoute) {
-  const userText = contextMenuPromptText(request);
+  const capturedPageText = await contextMenuPageText(request);
+  const baseText = contextMenuPromptText(request);
+  const userText = capturedPageText ? `${baseText}\n\n${capturedPageText}` : baseText;
   if (!userText) return false;
   let route = normalizeContextMenuRoute(requestedRoute);
   if (route === 'ask') route = settings.sessionId ? 'current' : 'new';
   if (route === 'current' && !settings.sessionId) route = 'new';
   if (route === 'new') {
-    await beginHermesBrowserDraft({ title: makeBrowserSessionTitle(), focus: false });
+    // Title the session from the task at birth, so right-click sessions never
+    // sit under the default "Hermes Browser Extension" name waiting for a
+    // post-turn rename (which can be gated by autoNameSessions / apiKey /
+    // remote-dashboard rename support). The derived title also makes the
+    // post-turn auto-title logic skip (title is no longer default).
+    const draftTitle = autoSessionTitleFromText(baseText) || makeBrowserSessionTitle();
+    await beginHermesBrowserDraft({ title: draftTitle, focus: false });
   }
   if (route === 'background') {
     const { session } = await runInlineDraftInBackground({ adapterId: 'right-click' }, userText);

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -23,7 +23,8 @@ import {
   contextControlState,
   contextMeterDisplay,
   CONTEXT_MENU_CONTEXTS,
-  DEFAULT_CONTEXT_MENU_ITEMS,
+  CONTEXT_MENU_INLINE_CONTEXTS,
+  CONTEXT_MENU_PROMPT_CONTEXTS,
   encodeSessionId,
   estimateContextWindow,
   estimateLocalSessionContextTokens,
@@ -409,6 +410,7 @@ const els = {
   contextMenuDefaultRoute: $('#contextMenuDefaultRoute'),
   contextMenuItemsList: $('#contextMenuItemsList'),
   contextMenuAddItem: $('#contextMenuAddItem'),
+  contextMenuEditorNotice: $('#contextMenuEditorNotice'),
   panelResidencyInputs: Array.from(document.querySelectorAll('input[name="panelResidencyMode"]')),
   autoNameSessionsInput: $('#autoNameSessionsInput'),
   transcriptProviderInput: $('#transcriptProviderInput'),
@@ -5998,11 +6000,15 @@ function renderContextMenuEditor() {
   if (!contextMenuEditorItems.length) initContextMenuEditorItems();
   const items = contextMenuEditorItems;
   list.innerHTML = '';
-  items.forEach((item, index) => {
+  items.forEach((item) => {
     const row = document.createElement('div');
     row.className = 'context-menu-item-row';
     row.dataset.id = item.id;
     row.setAttribute('role', 'listitem');
+
+    const resolveIndex = () => contextMenuEditorItems.findIndex((candidate) => candidate.id === row.dataset.id);
+    const resolveItem = () => contextMenuEditorItems.find((candidate) => candidate.id === row.dataset.id);
+    const mode = item.open ? 'open' : item.inlineAction ? 'inline' : 'prompt';
 
     const header = document.createElement('div');
     header.className = 'context-menu-item-header';
@@ -6012,7 +6018,12 @@ function renderContextMenuEditor() {
     toggle.checked = item.enabled !== false;
     toggle.title = 'Show or hide this item';
     toggle.addEventListener('change', () => {
-      contextMenuEditorItems[index].enabled = toggle.checked;
+      const current = resolveItem();
+      if (!current) {
+        renderContextMenuEditor();
+        return;
+      }
+      current.enabled = toggle.checked;
       persistContextMenuEditorItems();
     });
     header.appendChild(toggle);
@@ -6023,7 +6034,12 @@ function renderContextMenuEditor() {
     titleInput.placeholder = 'Menu label';
     titleInput.className = 'context-menu-item-title';
     titleInput.addEventListener('change', () => {
-      contextMenuEditorItems[index].title = titleInput.value.trim();
+      const current = resolveItem();
+      if (!current) {
+        renderContextMenuEditor();
+        return;
+      }
+      current.title = titleInput.value.trim();
       persistContextMenuEditorItems();
     });
     header.appendChild(titleInput);
@@ -6035,9 +6051,10 @@ function renderContextMenuEditor() {
     upBtn.type = 'button';
     upBtn.textContent = '↑';
     upBtn.className = 'secondary';
-    upBtn.disabled = index === 0;
+    upBtn.disabled = resolveIndex() <= 0;
     upBtn.title = 'Move up';
     upBtn.addEventListener('click', () => {
+      const index = resolveIndex();
       if (index > 0) {
         [contextMenuEditorItems[index - 1], contextMenuEditorItems[index]] = [contextMenuEditorItems[index], contextMenuEditorItems[index - 1]];
         persistContextMenuEditorItems();
@@ -6050,10 +6067,11 @@ function renderContextMenuEditor() {
     downBtn.type = 'button';
     downBtn.textContent = '↓';
     downBtn.className = 'secondary';
-    downBtn.disabled = index === items.length - 1;
+    downBtn.disabled = resolveIndex() === -1 || resolveIndex() === items.length - 1;
     downBtn.title = 'Move down';
     downBtn.addEventListener('click', () => {
-      if (index < items.length - 1) {
+      const index = resolveIndex();
+      if (index >= 0 && index < items.length - 1) {
         [contextMenuEditorItems[index], contextMenuEditorItems[index + 1]] = [contextMenuEditorItems[index + 1], contextMenuEditorItems[index]];
         persistContextMenuEditorItems();
         renderContextMenuEditor();
@@ -6067,9 +6085,12 @@ function renderContextMenuEditor() {
     removeBtn.className = 'secondary';
     removeBtn.title = 'Remove item';
     removeBtn.addEventListener('click', () => {
-      contextMenuEditorItems.splice(index, 1);
-      persistContextMenuEditorItems();
-      renderContextMenuEditor();
+      const index = resolveIndex();
+      if (index >= 0) {
+        contextMenuEditorItems.splice(index, 1);
+        persistContextMenuEditorItems();
+        renderContextMenuEditor();
+      }
     });
     controls.appendChild(removeBtn);
 
@@ -6084,6 +6105,12 @@ function renderContextMenuEditor() {
     contextsLabel.textContent = 'Show on:';
     detail.appendChild(contextsLabel);
 
+    const allowedContexts = mode === 'prompt'
+      ? CONTEXT_MENU_PROMPT_CONTEXTS
+      : mode === 'inline'
+        ? CONTEXT_MENU_INLINE_CONTEXTS
+        : CONTEXT_MENU_CONTEXTS.map((ctx) => ctx.value);
+
     const contextsSelect = document.createElement('div');
     contextsSelect.className = 'context-menu-contexts-checkboxes';
     CONTEXT_MENU_CONTEXTS.forEach((ctx) => {
@@ -6091,12 +6118,17 @@ function renderContextMenuEditor() {
       const ctxCheckbox = document.createElement('input');
       ctxCheckbox.type = 'checkbox';
       ctxCheckbox.checked = item.contexts.includes(ctx.value);
+      ctxCheckbox.disabled = !allowedContexts.includes(ctx.value);
       ctxCheckbox.addEventListener('change', () => {
-        const current = contextMenuEditorItems[index].contexts;
-        if (ctxCheckbox.checked && !current.includes(ctx.value)) {
-          current.push(ctx.value);
+        const current = resolveItem();
+        if (!current) {
+          renderContextMenuEditor();
+          return;
+        }
+        if (ctxCheckbox.checked && !current.contexts.includes(ctx.value)) {
+          current.contexts.push(ctx.value);
         } else if (!ctxCheckbox.checked) {
-          contextMenuEditorItems[index].contexts = current.filter((c) => c !== ctx.value);
+          current.contexts = current.contexts.filter((c) => c !== ctx.value);
         }
         persistContextMenuEditorItems();
       });
@@ -6108,7 +6140,6 @@ function renderContextMenuEditor() {
 
     const modeRow = document.createElement('div');
     modeRow.className = 'context-menu-mode-row';
-    const isInline = Boolean(item.inlineAction);
 
     const modeSelect = document.createElement('select');
     modeSelect.className = 'context-menu-mode-select';
@@ -6118,23 +6149,48 @@ function renderContextMenuEditor() {
     const inlineOpt = document.createElement('option');
     inlineOpt.value = 'inline';
     inlineOpt.textContent = 'Inline action';
+    const openOpt = document.createElement('option');
+    openOpt.value = 'open';
+    openOpt.textContent = 'Open Hermes Browser';
     modeSelect.appendChild(promptOpt);
     modeSelect.appendChild(inlineOpt);
-    modeSelect.value = isInline ? 'inline' : 'prompt';
+    modeSelect.appendChild(openOpt);
+    modeSelect.value = mode;
     modeSelect.addEventListener('change', () => {
-      if (modeSelect.value === 'inline') {
-        delete contextMenuEditorItems[index].prompt;
-        contextMenuEditorItems[index].inlineAction = INLINE_CONTEXT_ACTIONS[0].value;
+      const current = resolveItem();
+      if (!current) {
+        renderContextMenuEditor();
+        return;
+      }
+      if (modeSelect.value === 'open') {
+        current.open = true;
+        delete current.inlineAction;
+        delete current.prompt;
+        if (!current.contexts.length) current.contexts = ['page', 'link', 'image', 'video', 'audio'];
+      } else if (modeSelect.value === 'inline') {
+        delete current.open;
+        delete current.prompt;
+        current.inlineAction = INLINE_CONTEXT_ACTIONS[0].value;
+        current.contexts = current.contexts.filter((c) => CONTEXT_MENU_INLINE_CONTEXTS.includes(c));
+        if (!current.contexts.length) current.contexts = [...CONTEXT_MENU_INLINE_CONTEXTS];
       } else {
-        delete contextMenuEditorItems[index].inlineAction;
-        contextMenuEditorItems[index].prompt = contextMenuEditorItems[index].prompt || '';
+        delete current.open;
+        delete current.inlineAction;
+        current.prompt = current.prompt || '';
+        current.contexts = current.contexts.filter((c) => CONTEXT_MENU_PROMPT_CONTEXTS.includes(c));
+        if (!current.contexts.length) current.contexts = [...CONTEXT_MENU_PROMPT_CONTEXTS];
       }
       persistContextMenuEditorItems();
       renderContextMenuEditor();
     });
     modeRow.appendChild(modeSelect);
 
-    if (isInline) {
+    if (mode === 'open') {
+      const openNote = document.createElement('span');
+      openNote.className = 'context-menu-mode-note';
+      openNote.textContent = 'Opens the Hermes side panel.';
+      modeRow.appendChild(openNote);
+    } else if (mode === 'inline') {
       const inlineSelect = document.createElement('select');
       INLINE_CONTEXT_ACTIONS.forEach((action) => {
         const opt = document.createElement('option');
@@ -6144,7 +6200,12 @@ function renderContextMenuEditor() {
       });
       inlineSelect.value = item.inlineAction;
       inlineSelect.addEventListener('change', () => {
-        contextMenuEditorItems[index].inlineAction = inlineSelect.value;
+        const current = resolveItem();
+        if (!current) {
+          renderContextMenuEditor();
+          return;
+        }
+        current.inlineAction = inlineSelect.value;
         persistContextMenuEditorItems();
       });
       modeRow.appendChild(inlineSelect);
@@ -6155,7 +6216,12 @@ function renderContextMenuEditor() {
       promptInput.placeholder = 'Prompt sent to Hermes';
       promptInput.className = 'context-menu-prompt-input';
       promptInput.addEventListener('change', () => {
-        contextMenuEditorItems[index].prompt = promptInput.value;
+        const current = resolveItem();
+        if (!current) {
+          renderContextMenuEditor();
+          return;
+        }
+        current.prompt = promptInput.value;
         persistContextMenuEditorItems();
       });
       modeRow.appendChild(promptInput);
@@ -6174,19 +6240,41 @@ function initContextMenuEditorItems() {
   contextMenuEditorItems = normalizeContextMenuItems(settings.contextMenuItems).map((item) => ({ ...item }));
 }
 
+function clearContextMenuEditorNotice() {
+  if (!els.contextMenuEditorNotice) return;
+  els.contextMenuEditorNotice.hidden = true;
+  els.contextMenuEditorNotice.textContent = '';
+}
+
+function showContextMenuEditorNotice(message) {
+  if (!els.contextMenuEditorNotice) return;
+  els.contextMenuEditorNotice.textContent = message;
+  els.contextMenuEditorNotice.hidden = false;
+}
+
 function persistContextMenuEditorItems() {
-  settings = {
-    ...settings,
-    contextMenuItems: normalizeContextMenuItems(contextMenuEditorItems),
-  };
-  contextMenuEditorItems = normalizeContextMenuItems(settings.contextMenuItems).map((item) => ({ ...item }));
-  chrome.storage.local.set({ hermesBrowserSettings: settings }).catch((error) => {
-    console.warn('[Hermes Browser] Could not save context menu items:', error);
-  });
+  const previousLength = contextMenuEditorItems.length;
+  const normalized = normalizeContextMenuItems(contextMenuEditorItems);
+  contextMenuEditorItems = normalized.map((item) => ({ ...item }));
+  settings = { ...settings, contextMenuItems: normalized };
+  clearContextMenuEditorNotice();
+  chrome.storage.local.get('hermesBrowserSettings')
+    .then((stored) => {
+      const latestSettings = stored?.hermesBrowserSettings && typeof stored.hermesBrowserSettings === 'object'
+        ? stored.hermesBrowserSettings
+        : {};
+      settings = { ...settings, ...latestSettings, contextMenuItems: normalized };
+      return chrome.storage.local.set({ hermesBrowserSettings: settings });
+    })
+    .catch((error) => {
+      console.warn('[Hermes Browser] Could not save context menu items:', error);
+      showContextMenuEditorNotice(`Save failed: ${error?.message || String(error)}`);
+    });
+  if (normalized.length !== previousLength) renderContextMenuEditor();
 }
 
 function addContextMenuItem() {
-  const id = `hermes-browser-custom-${Date.now().toString(36)}`;
+  const id = `hermes-browser-custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
   contextMenuEditorItems.push({
     id,
     title: 'New action',
@@ -9146,6 +9234,18 @@ function bindEvents() {
       consumeVoiceDraft(changes[VOICE_DRAFT_STORAGE_KEY].newValue).catch((error) => {
         setStatus('warn', 'Voice transcript handoff failed', error?.message || String(error));
       });
+    }
+    const settingsChange = changes?.hermesBrowserSettings;
+    if (settingsChange) {
+      const next = settingsChange.newValue;
+      if (next && typeof next === 'object' && 'contextMenuItems' in next) {
+        settings = { ...settings, ...next };
+        contextMenuEditorItems = normalizeContextMenuItems(next.contextMenuItems).map((item) => ({ ...item }));
+        if (!els.settingsDialog?.hidden && els.contextMenuItemsList) renderContextMenuEditor();
+      } else if (!next || typeof next !== 'object') {
+        contextMenuEditorItems = normalizeContextMenuItems(undefined).map((item) => ({ ...item }));
+        if (!els.settingsDialog?.hidden && els.contextMenuItemsList) renderContextMenuEditor();
+      }
     }
   });
 }

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -24,7 +24,6 @@ import {
   contextMeterDisplay,
   CONTEXT_MENU_CONTEXTS,
   CONTEXT_MENU_INLINE_CONTEXTS,
-  CONTEXT_MENU_PROMPT_CONTEXTS,
   encodeSessionId,
   estimateContextWindow,
   estimateLocalSessionContextTokens,
@@ -6105,11 +6104,9 @@ function renderContextMenuEditor() {
     contextsLabel.textContent = 'Show on:';
     detail.appendChild(contextsLabel);
 
-    const allowedContexts = mode === 'prompt'
-      ? CONTEXT_MENU_PROMPT_CONTEXTS
-      : mode === 'inline'
-        ? CONTEXT_MENU_INLINE_CONTEXTS
-        : CONTEXT_MENU_CONTEXTS.map((ctx) => ctx.value);
+    const allowedContexts = mode === 'inline'
+      ? CONTEXT_MENU_INLINE_CONTEXTS
+      : CONTEXT_MENU_CONTEXTS.map((ctx) => ctx.value);
 
     const contextsSelect = document.createElement('div');
     contextsSelect.className = 'context-menu-contexts-checkboxes';
@@ -6177,8 +6174,7 @@ function renderContextMenuEditor() {
         delete current.open;
         delete current.inlineAction;
         current.prompt = current.prompt || '';
-        current.contexts = current.contexts.filter((c) => CONTEXT_MENU_PROMPT_CONTEXTS.includes(c));
-        if (!current.contexts.length) current.contexts = [...CONTEXT_MENU_PROMPT_CONTEXTS];
+        if (!current.contexts.length) current.contexts = ['selection'];
       }
       persistContextMenuEditorItems();
       renderContextMenuEditor();
@@ -8302,7 +8298,12 @@ function normalizeContextMenuRoute(value = '') {
 function contextMenuPromptText(request = {}) {
   const prompt = String(request.prompt || '').trim().slice(0, 500);
   const selection = String(request.selection || '').trim().slice(0, 8_000);
-  return prompt && selection ? `${prompt}\n\n${selection}` : '';
+  if (!prompt && !selection) return '';
+  const pageUrl = String(request.pageUrl || '').trim();
+  let text = prompt || selection;
+  if (prompt && selection) text = `${prompt}\n\n${selection}`;
+  else if (!selection && pageUrl) text = `${text}\n\nPage: ${pageUrl}`;
+  return text;
 }
 
 async function executeContextMenuRequest(request, requestedRoute) {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -22,6 +22,8 @@ import {
   contextChipSummary,
   contextControlState,
   contextMeterDisplay,
+  CONTEXT_MENU_CONTEXTS,
+  DEFAULT_CONTEXT_MENU_ITEMS,
   encodeSessionId,
   estimateContextWindow,
   estimateLocalSessionContextTokens,
@@ -39,6 +41,7 @@ import {
   isModelRuntimeSelectable,
   isRestrictedUrl,
   isUsableRemoteGatewayUrl,
+  INLINE_CONTEXT_ACTIONS,
   messageDisplayText,
   messagesForLocalCache,
   microphonePermissionHelp,
@@ -59,6 +62,8 @@ import {
   normalizeGatewayUrl,
   normalizeBrowserModelBinding,
   normalizeRuntimeModelPayload,
+  normalizeContextMenuItem,
+  normalizeContextMenuItems,
   normalizeSessionStartupMode,
   normalizeTextSize,
   normalizeToolActivity,
@@ -401,6 +406,8 @@ const els = {
   assistModelCapabilityHint: $('#assistModelCapabilityHint'),
   inlineAssistSessionRetention: $('#inlineAssistSessionRetention'),
   contextMenuDefaultRoute: $('#contextMenuDefaultRoute'),
+  contextMenuItemsList: $('#contextMenuItemsList'),
+  contextMenuAddItem: $('#contextMenuAddItem'),
   panelResidencyInputs: Array.from(document.querySelectorAll('input[name="panelResidencyMode"]')),
   autoNameSessionsInput: $('#autoNameSessionsInput'),
   transcriptProviderInput: $('#transcriptProviderInput'),
@@ -5979,9 +5986,216 @@ function syncSettingsForm() {
   if (els.wakeWordBrowserFallbackInput) els.wakeWordBrowserFallbackInput.checked = settings.wakeWordBrowserFallback !== false;
   if (els.wakeWordSpeakRepliesInput) els.wakeWordSpeakRepliesInput.checked = settings.wakeWordSpeakReplies !== false;
   renderWakeState();
+  renderContextMenuEditor();
   renderCompatibilityPanel();
   renderConnectionSecurity();
   renderRemoteDiagnostics(lastRemoteDiagnostic);
+}
+
+function renderContextMenuEditor() {
+  const list = els.contextMenuItemsList;
+  if (!list) return;
+  if (!contextMenuEditorItems.length) initContextMenuEditorItems();
+  const items = contextMenuEditorItems;
+  list.innerHTML = '';
+  items.forEach((item, index) => {
+    const row = document.createElement('div');
+    row.className = 'context-menu-item-row';
+    row.dataset.id = item.id;
+    row.setAttribute('role', 'listitem');
+
+    const header = document.createElement('div');
+    header.className = 'context-menu-item-header';
+
+    const toggle = document.createElement('input');
+    toggle.type = 'checkbox';
+    toggle.checked = item.enabled !== false;
+    toggle.title = 'Show or hide this item';
+    toggle.addEventListener('change', () => {
+      contextMenuEditorItems[index].enabled = toggle.checked;
+      persistContextMenuEditorItems();
+    });
+    header.appendChild(toggle);
+
+    const titleInput = document.createElement('input');
+    titleInput.type = 'text';
+    titleInput.value = item.title;
+    titleInput.placeholder = 'Menu label';
+    titleInput.className = 'context-menu-item-title';
+    titleInput.addEventListener('change', () => {
+      contextMenuEditorItems[index].title = titleInput.value.trim();
+      persistContextMenuEditorItems();
+    });
+    header.appendChild(titleInput);
+
+    const controls = document.createElement('div');
+    controls.className = 'context-menu-item-controls';
+
+    const upBtn = document.createElement('button');
+    upBtn.type = 'button';
+    upBtn.textContent = '↑';
+    upBtn.className = 'secondary';
+    upBtn.disabled = index === 0;
+    upBtn.title = 'Move up';
+    upBtn.addEventListener('click', () => {
+      if (index > 0) {
+        [contextMenuEditorItems[index - 1], contextMenuEditorItems[index]] = [contextMenuEditorItems[index], contextMenuEditorItems[index - 1]];
+        persistContextMenuEditorItems();
+        renderContextMenuEditor();
+      }
+    });
+    controls.appendChild(upBtn);
+
+    const downBtn = document.createElement('button');
+    downBtn.type = 'button';
+    downBtn.textContent = '↓';
+    downBtn.className = 'secondary';
+    downBtn.disabled = index === items.length - 1;
+    downBtn.title = 'Move down';
+    downBtn.addEventListener('click', () => {
+      if (index < items.length - 1) {
+        [contextMenuEditorItems[index], contextMenuEditorItems[index + 1]] = [contextMenuEditorItems[index + 1], contextMenuEditorItems[index]];
+        persistContextMenuEditorItems();
+        renderContextMenuEditor();
+      }
+    });
+    controls.appendChild(downBtn);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '✕';
+    removeBtn.className = 'secondary';
+    removeBtn.title = 'Remove item';
+    removeBtn.addEventListener('click', () => {
+      contextMenuEditorItems.splice(index, 1);
+      persistContextMenuEditorItems();
+      renderContextMenuEditor();
+    });
+    controls.appendChild(removeBtn);
+
+    header.appendChild(controls);
+    row.appendChild(header);
+
+    const detail = document.createElement('div');
+    detail.className = 'context-menu-item-detail';
+
+    const contextsLabel = document.createElement('span');
+    contextsLabel.className = 'context-menu-item-label';
+    contextsLabel.textContent = 'Show on:';
+    detail.appendChild(contextsLabel);
+
+    const contextsSelect = document.createElement('div');
+    contextsSelect.className = 'context-menu-contexts-checkboxes';
+    CONTEXT_MENU_CONTEXTS.forEach((ctx) => {
+      const ctxLabel = document.createElement('label');
+      const ctxCheckbox = document.createElement('input');
+      ctxCheckbox.type = 'checkbox';
+      ctxCheckbox.checked = item.contexts.includes(ctx.value);
+      ctxCheckbox.addEventListener('change', () => {
+        const current = contextMenuEditorItems[index].contexts;
+        if (ctxCheckbox.checked && !current.includes(ctx.value)) {
+          current.push(ctx.value);
+        } else if (!ctxCheckbox.checked) {
+          contextMenuEditorItems[index].contexts = current.filter((c) => c !== ctx.value);
+        }
+        persistContextMenuEditorItems();
+      });
+      ctxLabel.appendChild(ctxCheckbox);
+      ctxLabel.append(ctx.label);
+      contextsSelect.appendChild(ctxLabel);
+    });
+    detail.appendChild(contextsSelect);
+
+    const modeRow = document.createElement('div');
+    modeRow.className = 'context-menu-mode-row';
+    const isInline = Boolean(item.inlineAction);
+
+    const modeSelect = document.createElement('select');
+    modeSelect.className = 'context-menu-mode-select';
+    const promptOpt = document.createElement('option');
+    promptOpt.value = 'prompt';
+    promptOpt.textContent = 'Send prompt';
+    const inlineOpt = document.createElement('option');
+    inlineOpt.value = 'inline';
+    inlineOpt.textContent = 'Inline action';
+    modeSelect.appendChild(promptOpt);
+    modeSelect.appendChild(inlineOpt);
+    modeSelect.value = isInline ? 'inline' : 'prompt';
+    modeSelect.addEventListener('change', () => {
+      if (modeSelect.value === 'inline') {
+        delete contextMenuEditorItems[index].prompt;
+        contextMenuEditorItems[index].inlineAction = INLINE_CONTEXT_ACTIONS[0].value;
+      } else {
+        delete contextMenuEditorItems[index].inlineAction;
+        contextMenuEditorItems[index].prompt = contextMenuEditorItems[index].prompt || '';
+      }
+      persistContextMenuEditorItems();
+      renderContextMenuEditor();
+    });
+    modeRow.appendChild(modeSelect);
+
+    if (isInline) {
+      const inlineSelect = document.createElement('select');
+      INLINE_CONTEXT_ACTIONS.forEach((action) => {
+        const opt = document.createElement('option');
+        opt.value = action.value;
+        opt.textContent = action.label;
+        inlineSelect.appendChild(opt);
+      });
+      inlineSelect.value = item.inlineAction;
+      inlineSelect.addEventListener('change', () => {
+        contextMenuEditorItems[index].inlineAction = inlineSelect.value;
+        persistContextMenuEditorItems();
+      });
+      modeRow.appendChild(inlineSelect);
+    } else {
+      const promptInput = document.createElement('input');
+      promptInput.type = 'text';
+      promptInput.value = item.prompt || '';
+      promptInput.placeholder = 'Prompt sent to Hermes';
+      promptInput.className = 'context-menu-prompt-input';
+      promptInput.addEventListener('change', () => {
+        contextMenuEditorItems[index].prompt = promptInput.value;
+        persistContextMenuEditorItems();
+      });
+      modeRow.appendChild(promptInput);
+    }
+
+    detail.appendChild(modeRow);
+    row.appendChild(detail);
+
+    list.appendChild(row);
+  });
+}
+
+let contextMenuEditorItems = [];
+
+function initContextMenuEditorItems() {
+  contextMenuEditorItems = normalizeContextMenuItems(settings.contextMenuItems).map((item) => ({ ...item }));
+}
+
+function persistContextMenuEditorItems() {
+  settings = {
+    ...settings,
+    contextMenuItems: normalizeContextMenuItems(contextMenuEditorItems),
+  };
+  contextMenuEditorItems = normalizeContextMenuItems(settings.contextMenuItems).map((item) => ({ ...item }));
+  chrome.storage.local.set({ hermesBrowserSettings: settings }).catch((error) => {
+    console.warn('[Hermes Browser] Could not save context menu items:', error);
+  });
+}
+
+function addContextMenuItem() {
+  const id = `hermes-browser-custom-${Date.now().toString(36)}`;
+  contextMenuEditorItems.push({
+    id,
+    title: 'New action',
+    contexts: ['selection'],
+    prompt: '',
+    enabled: true,
+  });
+  persistContextMenuEditorItems();
+  renderContextMenuEditor();
 }
 
 async function saveSettingsFromForm() {
@@ -8554,6 +8768,9 @@ function bindEvents() {
   });
   els.contextMenuRouteNotice?.addEventListener('click', (event) => {
     handleContextMenuRouteChoice(event).catch((error) => setStatus('error', 'Right-click task failed', error?.message || String(error)));
+  });
+  els.contextMenuAddItem?.addEventListener('click', () => {
+    addContextMenuItem();
   });
   els.modelMenuButton.addEventListener('click', (event) => {
     event.stopPropagation();

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -8306,25 +8306,14 @@ function contextMenuPromptText(request = {}) {
   return text;
 }
 
-async function contextMenuPageText(request = {}) {
-  // Page-level prompt items carry only the page URL (background.js writes
-  // selection: '' for page contexts). Capture the actual page content so the
-  // task can work with the page itself — selection items already carry their
-  // content and skip capture. Depth honors the control-panel setting
-  // (contextDepth: minimal / normal / full). Failure degrades to URL-only,
-  // never drops the request.
-  if (!request.pageUrl || request.selection || !Number.isFinite(request.tabId)) return '';
-  const tab = await chrome.tabs.get(request.tabId).catch(() => null);
-  if (!tab) return '';
-  const pageContext = await getPageContext(tab, {});
-  if (!pageContext?.ok || !pageContext.text) return '';
-  return pageContext.text;
-}
-
 async function executeContextMenuRequest(request, requestedRoute) {
-  const capturedPageText = await contextMenuPageText(request);
-  const baseText = contextMenuPromptText(request);
-  const userText = capturedPageText ? `${baseText}\n\n${capturedPageText}` : baseText;
+  // The right-click path no longer forces chat-only. askHermes calls
+  // refreshContext(), which honors the user's context scope setting and
+  // contextDepth — the same pipeline the composer uses. Selection items
+  // carry their text in the prompt; page-context items get the page DOM
+  // through the normal browser_context attachment, not folded into the
+  // prompt body. The user's "Page context depth" setting controls this.
+  const userText = contextMenuPromptText(request);
   if (!userText) return false;
   let route = normalizeContextMenuRoute(requestedRoute);
   if (route === 'ask') route = settings.sessionId ? 'current' : 'new';
@@ -8335,7 +8324,7 @@ async function executeContextMenuRequest(request, requestedRoute) {
     // post-turn rename (which can be gated by autoNameSessions / apiKey /
     // remote-dashboard rename support). The derived title also makes the
     // post-turn auto-title logic skip (title is no longer default).
-    const draftTitle = autoSessionTitleFromText(baseText) || makeBrowserSessionTitle();
+  const draftTitle = autoSessionTitleFromText(userText) || makeBrowserSessionTitle();
     await beginHermesBrowserDraft({ title: draftTitle, focus: false });
   }
   if (route === 'background') {
@@ -8349,7 +8338,6 @@ async function executeContextMenuRequest(request, requestedRoute) {
   if (route === 'current' && settings.sessionId) approvedForeignSessionIds.add(String(settings.sessionId));
   els.input.value = '';
   const sent = await askHermes(userText, [], {
-    forceChatOnly: true,
     preserveComposer: true,
     disableCommandParsing: true,
     displayUserText: `Right-click task · ${String(request.prompt || '').replace(/:$/, '')}`,

--- a/tests/browser-runtime.test.mjs
+++ b/tests/browser-runtime.test.mjs
@@ -203,6 +203,7 @@ function createBackgroundHarness({
   const contextMenuCreateCalls = [];
   const contextMenuSessionWrites = [];
   const storedSettings = { panelResidencyMode };
+  const callLog = [];
   let contextMenuRemoveAllCalls = 0;
   let actionHandler = null;
   let installedHandler = null;
@@ -220,13 +221,19 @@ function createBackgroundHarness({
     },
     storage: {
       local: {
-        get: async () => ({
-          hermesBrowserSettings: { ...storedSettings },
-        }),
+        get: async () => {
+          callLog.push('storage.local.get');
+          return {
+            hermesBrowserSettings: { ...storedSettings },
+          };
+        },
       },
       session: {
         get: async () => ({}),
-        set: async (value) => { contextMenuSessionWrites.push(value); },
+        set: async (value) => {
+          callLog.push('storage.session.set');
+          contextMenuSessionWrites.push(value);
+        },
         remove: async () => {},
       },
       onChanged: { addListener(handler) { storageChangedHandler = handler; } },
@@ -244,6 +251,7 @@ function createBackgroundHarness({
         return snapshot;
       },
       create: async (options) => {
+        callLog.push('tabs.create');
         createdTabs.push(options);
         const created = { id: 100 + createdTabs.length, windowId: 8, pendingUrl: options.url };
         extensionTabs.push(created);
@@ -253,12 +261,14 @@ function createBackgroundHarness({
         updatedTabs.push({ tabId, options });
         return extensionTabs.find((tab) => tab.id === tabId) || null;
       },
+      sendMessage: async () => ({ ok: true }),
       onActivated: { addListener() {} },
     },
     sidePanel: {
       setPanelBehavior: async () => {},
       setOptions: async (options) => { sidePanelOptions.push(options); },
       open: async (options) => {
+        callLog.push('sidePanel.open');
         sidePanelOpenCalls.push(options);
         return sidePanelOpen(options);
       },
@@ -297,6 +307,7 @@ function createBackgroundHarness({
     sidePanelOpenCalls,
     sidePanelOptions,
     contextMenuCreateCalls,
+    callLog,
     get contextMenuRemoveAllCalls() { return contextMenuRemoveAllCalls; },
     get actionHandler() { return actionHandler; },
     get installedHandler() { return installedHandler; },
@@ -512,6 +523,120 @@ test('background falls back to a tab when the side panel cannot open', async () 
       { id: 7, windowId: 8 },
     );
     assert.equal(harness.createdTabs.length, 1, 'when the side panel throws, the fallback tab must open');
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background summons the side panel inside the gesture for an open-action item', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness();
+  harness.setStoredContextMenuItems([{
+    id: 'hermes-browser-open',
+    title: 'Open Hermes Browser',
+    contexts: ['page', 'link', 'image', 'video', 'audio'],
+    enabled: true,
+  }]);
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?gesture-open=${Date.now()}`);
+    await harness.installedHandler();
+    harness.callLog.length = 0;
+    await harness.contextMenuClickedHandler(
+      { menuItemId: 'hermes-browser-open', pageUrl: 'https://example.com' },
+      { id: 7, windowId: 8 },
+    );
+    assert.equal(harness.callLog[0], 'sidePanel.open', 'the side panel must be asked to open before any awaited API');
+    assert.deepEqual(harness.sidePanelOpenCalls, [{ tabId: 7 }], 'tab-attached mode opens for the clicked tab');
+    assert.equal(harness.createdTabs.length, 0, 'an answered side-panel open must not open a fallback tab');
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background writes the context-menu request after summoning the panel within the gesture', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness();
+  harness.setStoredContextMenuItems([{
+    id: 'ingest-this',
+    title: 'Ingest this',
+    contexts: ['page', 'link', 'image', 'video', 'audio'],
+    prompt: 'Run /ingest for this page',
+  }]);
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?gesture-prompt=${Date.now()}`);
+    await harness.installedHandler();
+    harness.callLog.length = 0;
+    await harness.contextMenuClickedHandler(
+      { menuItemId: 'ingest-this', pageUrl: 'https://example.com/article' },
+      { id: 7, windowId: 8 },
+    );
+    assert.equal(harness.callLog[0], 'sidePanel.open', 'the side panel must be asked to open before any awaited API');
+    assert.ok(
+      harness.callLog.indexOf('sidePanel.open') < harness.callLog.indexOf('storage.session.set'),
+      'the request must be written only after the in-gesture summon',
+    );
+    const writes = harness.contextMenuSessionWrites.filter((value) => value.hermesBrowserContextMenuRequest);
+    assert.equal(writes.length, 1, 'a page-context prompt click must write a request');
+    assert.equal(writes[0].hermesBrowserContextMenuRequest.prompt, 'Run /ingest for this page');
+    assert.equal(harness.createdTabs.length, 0, 'an answered side-panel open must not open a fallback tab');
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background writes the request and falls back to a tab when the in-gesture summon is refused', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness({
+    sidePanelOpen: async () => { throw new Error('sidePanel.open() may only be called in response to a user gesture.'); },
+  });
+  harness.setStoredContextMenuItems([{
+    id: 'ingest-this',
+    title: 'Ingest this',
+    contexts: ['page'],
+    prompt: 'Run /ingest for this page',
+  }]);
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?gesture-refused=${Date.now()}`);
+    await harness.installedHandler();
+    await harness.contextMenuClickedHandler(
+      { menuItemId: 'ingest-this', pageUrl: 'https://example.com/article' },
+      { id: 7, windowId: 8 },
+    );
+    const writes = harness.contextMenuSessionWrites.filter((value) => value.hermesBrowserContextMenuRequest);
+    assert.equal(writes.length, 1, 'the request must be written even when the panel is refused');
+    assert.equal(harness.createdTabs.length, 1, 'a refused side-panel open falls back to the extension tab');
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background never summons the panel for an inline-action item', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness();
+  harness.setStoredContextMenuItems([{
+    id: 'summarize',
+    title: 'Summarize selection',
+    contexts: ['editable'],
+    inlineAction: 'summarize',
+  }]);
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?gesture-inline=${Date.now()}`);
+    await harness.installedHandler();
+    harness.callLog.length = 0;
+    await harness.contextMenuClickedHandler(
+      { menuItemId: 'summarize', pageUrl: 'https://example.com' },
+      { id: 7, windowId: 8 },
+    );
+    assert.equal(harness.sidePanelOpenCalls.length, 0, 'inline actions are handled by the content script, not the panel');
+    assert.equal(harness.createdTabs.length, 0);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/tests/browser-runtime.test.mjs
+++ b/tests/browser-runtime.test.mjs
@@ -280,7 +280,11 @@ function createBackgroundHarness({
         contextMenuCreateCalls.push(options);
         callback?.();
       },
-      onClicked: { addListener(handler) { contextMenuClickedHandler = handler; } },
+      onClicked: {
+        addListener(handler) {
+          contextMenuClickedHandler = (info, tab) => handler(info, tab);
+        },
+      },
     },
   };
 
@@ -455,6 +459,59 @@ test('background hands a page-context prompt item to the panel instead of silent
     assert.equal(request.prompt, 'Run /ingest for this page');
     assert.equal(request.selection, '');
     assert.equal(request.pageUrl, 'https://example.com/article');
+    assert.equal(harness.createdTabs.length, 0, 'an answered side-panel open must not open a fallback tab');
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background opens the side panel for an open-action item without a fallback tab', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness();
+  harness.setStoredContextMenuItems([{
+    id: 'hermes-browser-open',
+    title: 'Open Hermes Browser',
+    contexts: ['page', 'link', 'image', 'video', 'audio'],
+    enabled: true,
+  }]);
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?open-action-lenient=${Date.now()}`);
+    await harness.installedHandler();
+    assert.equal(typeof harness.contextMenuClickedHandler, 'function');
+    await harness.contextMenuClickedHandler(
+      { menuItemId: 'hermes-browser-open', pageUrl: 'https://example.com' },
+      { id: 7, windowId: 8 },
+    );
+    assert.equal(harness.sidePanelOpenCalls.length, 1, 'the side panel must be asked to open');
+    assert.equal(harness.createdTabs.length, 0, 'an answered side-panel open must not open a fallback tab');
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background falls back to a tab when the side panel cannot open', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness({
+    sidePanelOpen: async () => { throw new Error('side panel unavailable'); },
+  });
+  harness.setStoredContextMenuItems([{
+    id: 'hermes-browser-open',
+    title: 'Open Hermes Browser',
+    contexts: ['page'],
+    enabled: true,
+  }]);
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?open-action-fallback=${Date.now()}`);
+    await harness.installedHandler();
+    await harness.contextMenuClickedHandler(
+      { menuItemId: 'hermes-browser-open', pageUrl: 'https://example.com' },
+      { id: 7, windowId: 8 },
+    );
+    assert.equal(harness.createdTabs.length, 1, 'when the side panel throws, the fallback tab must open');
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/tests/browser-runtime.test.mjs
+++ b/tests/browser-runtime.test.mjs
@@ -201,12 +201,14 @@ function createBackgroundHarness({
   const sidePanelOpenCalls = [];
   const sidePanelOptions = [];
   const contextMenuCreateCalls = [];
+  const contextMenuSessionWrites = [];
   const storedSettings = { panelResidencyMode };
   let contextMenuRemoveAllCalls = 0;
   let actionHandler = null;
   let installedHandler = null;
   let startupHandler = null;
   let storageChangedHandler = null;
+  let contextMenuClickedHandler = null;
   const chromeApi = {
     runtime: {
       getManifest: () => ({ side_panel: { default_path: 'sidepanel.html' } }),
@@ -221,6 +223,11 @@ function createBackgroundHarness({
         get: async () => ({
           hermesBrowserSettings: { ...storedSettings },
         }),
+      },
+      session: {
+        get: async () => ({}),
+        set: async (value) => { contextMenuSessionWrites.push(value); },
+        remove: async () => {},
       },
       onChanged: { addListener(handler) { storageChangedHandler = handler; } },
     },
@@ -273,6 +280,7 @@ function createBackgroundHarness({
         contextMenuCreateCalls.push(options);
         callback?.();
       },
+      onClicked: { addListener(handler) { contextMenuClickedHandler = handler; } },
     },
   };
 
@@ -290,6 +298,8 @@ function createBackgroundHarness({
     get installedHandler() { return installedHandler; },
     get startupHandler() { return startupHandler; },
     get storageChangedHandler() { return storageChangedHandler; },
+    get contextMenuClickedHandler() { return contextMenuClickedHandler; },
+    get contextMenuSessionWrites() { return contextMenuSessionWrites; },
     setStoredContextMenuItems(items) { storedSettings.contextMenuItems = items; },
   };
 }
@@ -415,6 +425,36 @@ test('background rebuilds the menu when contextMenuItems is deleted or reset', a
     await new Promise((resolve) => setTimeout(resolve, 80));
     assert.equal(harness.contextMenuRemoveAllCalls, 1, 'a removed contextMenuItems key must trigger a rebuild');
     assert.equal(harness.contextMenuCreateCalls.length, 7, 'deleted items must rebuild the default menu plus the root');
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background hands a page-context prompt item to the panel instead of silently no-opping', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness();
+  harness.setStoredContextMenuItems([{
+    id: 'ingest-this',
+    title: 'Ingest this',
+    contexts: ['page', 'link', 'image', 'video', 'audio'],
+    prompt: 'Run /ingest for this page',
+  }]);
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?page-prompt-item=${Date.now()}`);
+    await harness.installedHandler();
+    assert.equal(typeof harness.contextMenuClickedHandler, 'function');
+    await harness.contextMenuClickedHandler(
+      { menuItemId: 'ingest-this', pageUrl: 'https://example.com/article' },
+      { id: 7, windowId: 8 },
+    );
+    const writes = harness.contextMenuSessionWrites.filter((value) => value.hermesBrowserContextMenuRequest);
+    assert.equal(writes.length, 1, 'a page-context prompt click must write a request');
+    const request = writes[0].hermesBrowserContextMenuRequest;
+    assert.equal(request.prompt, 'Run /ingest for this page');
+    assert.equal(request.selection, '');
+    assert.equal(request.pageUrl, 'https://example.com/article');
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/tests/browser-runtime.test.mjs
+++ b/tests/browser-runtime.test.mjs
@@ -201,10 +201,12 @@ function createBackgroundHarness({
   const sidePanelOpenCalls = [];
   const sidePanelOptions = [];
   const contextMenuCreateCalls = [];
+  const storedSettings = { panelResidencyMode };
   let contextMenuRemoveAllCalls = 0;
   let actionHandler = null;
   let installedHandler = null;
   let startupHandler = null;
+  let storageChangedHandler = null;
   const chromeApi = {
     runtime: {
       getManifest: () => ({ side_panel: { default_path: 'sidepanel.html' } }),
@@ -217,10 +219,10 @@ function createBackgroundHarness({
     storage: {
       local: {
         get: async () => ({
-          hermesBrowserSettings: { panelResidencyMode },
+          hermesBrowserSettings: { ...storedSettings },
         }),
       },
-      onChanged: { addListener() {} },
+      onChanged: { addListener(handler) { storageChangedHandler = handler; } },
     },
     action: {
       setPopup: async () => {},
@@ -287,6 +289,8 @@ function createBackgroundHarness({
     get actionHandler() { return actionHandler; },
     get installedHandler() { return installedHandler; },
     get startupHandler() { return startupHandler; },
+    get storageChangedHandler() { return storageChangedHandler; },
+    setStoredContextMenuItems(items) { storedSettings.contextMenuItems = items; },
   };
 }
 
@@ -348,6 +352,69 @@ test('background retries context-menu configuration after a failed removal', asy
     await harness.startupHandler();
     assert.equal(harness.contextMenuRemoveAllCalls, 2, 'a failed attempt must not poison later lifecycle retries');
     assert.equal(harness.contextMenuCreateCalls.length, 7);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background serializes rapid context-menu rebuilds so removeAll/create cannot overlap', async () => {
+  const originalChrome = globalThis.chrome;
+  let activeRemoveAll = 0;
+  let maxConcurrentRemoveAll = 0;
+  const harness = createBackgroundHarness({
+    contextMenuRemoveAll: async () => {
+      activeRemoveAll += 1;
+      maxConcurrentRemoveAll = Math.max(maxConcurrentRemoveAll, activeRemoveAll);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      activeRemoveAll -= 1;
+    },
+  });
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?rebuild-serialization=${Date.now()}`);
+    const handler = harness.storageChangedHandler;
+    assert.equal(typeof handler, 'function');
+    const trigger = (items) => handler({ hermesBrowserSettings: { newValue: { contextMenuItems: items } } }, 'local');
+    const settle = (ms = 35) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    harness.setStoredContextMenuItems([{ id: 'a', title: 'A', contexts: ['selection'] }]);
+    trigger([{ id: 'a', title: 'A', contexts: ['selection'] }]);
+    await settle();
+    harness.setStoredContextMenuItems([{ id: 'b', title: 'B', contexts: ['selection'] }]);
+    trigger([{ id: 'b', title: 'B', contexts: ['selection'] }]);
+    await settle();
+    harness.setStoredContextMenuItems([{ id: 'c', title: 'C', contexts: ['selection'] }]);
+    trigger([{ id: 'c', title: 'C', contexts: ['selection'] }]);
+    await settle(200);
+
+    assert.equal(maxConcurrentRemoveAll, 1, 'rapid rebuilds must never overlap removeAll()');
+    assert.equal(harness.contextMenuRemoveAllCalls, 3, 'each rebuild must re-read the latest configuration');
+    const lastCreate = harness.contextMenuCreateCalls[harness.contextMenuCreateCalls.length - 1];
+    assert.equal(lastCreate.id, 'c', 'the final generation must win');
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('background rebuilds the menu when contextMenuItems is deleted or reset', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness();
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?context-menu-deleted=${Date.now()}`);
+    const handler = harness.storageChangedHandler;
+    assert.equal(typeof handler, 'function');
+    handler({
+      hermesBrowserSettings: {
+        oldValue: { contextMenuItems: [{ id: 'x', title: 'X', contexts: ['selection'] }] },
+        newValue: {},
+      },
+    }, 'local');
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal(harness.contextMenuRemoveAllCalls, 1, 'a removed contextMenuItems key must trigger a rebuild');
+    assert.equal(harness.contextMenuCreateCalls.length, 7, 'deleted items must rebuild the default menu plus the root');
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/tests/context-menu-page-capture.test.mjs
+++ b/tests/context-menu-page-capture.test.mjs
@@ -5,32 +5,35 @@ import test from 'node:test';
 const root = new URL('../', import.meta.url);
 const read = (file) => readFile(new URL(file, root), 'utf8');
 
-test('right-click page contexts capture the page text through the existing context pipeline', async () => {
-  const source = await read('extension/sidepanel.js');
-  assert.match(source, /async function contextMenuPageText\(request = \{\}\)/);
-  assert.match(source, /if \(!request\.pageUrl \|\| request\.selection \|\| !Number\.isFinite\(request\.tabId\)\) return '';/);
-  assert.match(source, /const tab = await chrome\.tabs\.get\(request\.tabId\)\.catch\(\(\) => null\);/);
-  assert.match(source, /const pageContext = await getPageContext\(tab, \{\}\)/);
-  assert.match(source, /if \(!pageContext\?\.ok \|\| !pageContext\.text\) return '';/);
-});
-
-test('captured page text is folded into the task and failure degrades to URL-only', async () => {
+test('right-click tasks do not force chat-only so browser context attaches per the user setting', async () => {
   const source = await read('extension/sidepanel.js');
   const execute = source.match(/async function executeContextMenuRequest\(request, requestedRoute\) \{[\s\S]*?\n\}/)?.[0] || '';
-  assert.match(execute, /const capturedPageText = await contextMenuPageText\(request\);/);
-  assert.match(execute, /const baseText = contextMenuPromptText\(request\);/);
-  assert.match(execute, /const userText = capturedPageText \? `\$\{baseText\}\\n\\n\$\{capturedPageText\}` : baseText;/);
-  assert.match(execute, /if \(!userText\) return false;/);
+  assert.ok(execute, 'executeContextMenuRequest must exist');
+  // forceChatOnly must NOT appear in the askHermes call — its presence forced
+  // refreshContext() to skip, nulled the browser context, and showed
+  // "Chat only — no browser context attached" for every right-click task.
+  const askCall = execute.match(/await askHermes\(userText, \[\], \{[\s\S]*?\}\)/)?.[0] || '';
+  assert.ok(askCall, 'executeContextMenuRequest must call askHermes');
+  assert.doesNotMatch(askCall, /forceChatOnly/, 'right-click tasks must not force chat-only');
 });
 
-test('capture honors the control-panel contextDepth setting used by getPageContext', async () => {
+test('right-click tasks use contextMenuPromptText for the user message (no separate page-text capture)', async () => {
+  const source = await read('extension/sidepanel.js');
+  // The old contextMenuPageText helper is gone — page content now arrives
+  // through refreshContext → browser_context, not folded into the prompt.
+  assert.doesNotMatch(source, /async function contextMenuPageText/);
+  const execute = source.match(/async function executeContextMenuRequest\(request, requestedRoute\) \{[\s\S]*?\n\}/)?.[0] || '';
+  assert.match(execute, /contextMenuPromptText\(request\)/);
+});
+
+test('getPageContext honors the control-panel contextDepth setting so right-click context inherits it', async () => {
   const [source, common] = await Promise.all([
     read('extension/sidepanel.js'),
     read('extension/lib/common.mjs'),
   ]);
   assert.match(common, /contextDepth: 'normal'/);
   // getPageContext reads the depth from settings, not from the options object,
-  // so the right-click capture inherits the control-panel choice for free.
+  // so refreshContext → getPageContext inherits the control-panel choice.
   assert.match(source, /const requestOptions = \{\s*depth: settings\.contextDepth,/);
   assert.match(source, /contextDepthInput: \$\(['"]#contextDepthInput['"]\)/);
 });
@@ -38,7 +41,7 @@ test('capture honors the control-panel contextDepth setting used by getPageConte
 test('right-click new sessions are titled from the task text at creation', async () => {
   const source = await read('extension/sidepanel.js');
   const execute = source.match(/async function executeContextMenuRequest\(request, requestedRoute\) \{[\s\S]*?\n\}/)?.[0] || '';
-  assert.match(execute, /const draftTitle = autoSessionTitleFromText\(baseText\) \|\| makeBrowserSessionTitle\(\);/);
+  assert.match(execute, /const draftTitle = autoSessionTitleFromText\(userText\) \|\| makeBrowserSessionTitle\(\);/);
   assert.match(execute, /beginHermesBrowserDraft\(\{ title: draftTitle, focus: false \}\)/);
 });
 

--- a/tests/context-menu-page-capture.test.mjs
+++ b/tests/context-menu-page-capture.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const root = new URL('../', import.meta.url);
+const read = (file) => readFile(new URL(file, root), 'utf8');
+
+test('right-click page contexts capture the page text through the existing context pipeline', async () => {
+  const source = await read('extension/sidepanel.js');
+  assert.match(source, /async function contextMenuPageText\(request = \{\}\)/);
+  assert.match(source, /if \(!request\.pageUrl \|\| request\.selection \|\| !Number\.isFinite\(request\.tabId\)\) return '';/);
+  assert.match(source, /const tab = await chrome\.tabs\.get\(request\.tabId\)\.catch\(\(\) => null\);/);
+  assert.match(source, /const pageContext = await getPageContext\(tab, \{\}\)/);
+  assert.match(source, /if \(!pageContext\?\.ok \|\| !pageContext\.text\) return '';/);
+});
+
+test('captured page text is folded into the task and failure degrades to URL-only', async () => {
+  const source = await read('extension/sidepanel.js');
+  const execute = source.match(/async function executeContextMenuRequest\(request, requestedRoute\) \{[\s\S]*?\n\}/)?.[0] || '';
+  assert.match(execute, /const capturedPageText = await contextMenuPageText\(request\);/);
+  assert.match(execute, /const baseText = contextMenuPromptText\(request\);/);
+  assert.match(execute, /const userText = capturedPageText \? `\$\{baseText\}\\n\\n\$\{capturedPageText\}` : baseText;/);
+  assert.match(execute, /if \(!userText\) return false;/);
+});
+
+test('capture honors the control-panel contextDepth setting used by getPageContext', async () => {
+  const [source, common] = await Promise.all([
+    read('extension/sidepanel.js'),
+    read('extension/lib/common.mjs'),
+  ]);
+  assert.match(common, /contextDepth: 'normal'/);
+  // getPageContext reads the depth from settings, not from the options object,
+  // so the right-click capture inherits the control-panel choice for free.
+  assert.match(source, /const requestOptions = \{\s*depth: settings\.contextDepth,/);
+  assert.match(source, /contextDepthInput: \$\(['"]#contextDepthInput['"]\)/);
+});
+
+test('right-click new sessions are titled from the task text at creation', async () => {
+  const source = await read('extension/sidepanel.js');
+  const execute = source.match(/async function executeContextMenuRequest\(request, requestedRoute\) \{[\s\S]*?\n\}/)?.[0] || '';
+  assert.match(execute, /const draftTitle = autoSessionTitleFromText\(baseText\) \|\| makeBrowserSessionTitle\(\);/);
+  assert.match(execute, /beginHermesBrowserDraft\(\{ title: draftTitle, focus: false \}\)/);
+});
+
+test('title-at-creation keeps the post-turn auto-title from double-renaming', async () => {
+  const source = await read('extension/sidepanel.js');
+  // The derived title is non-default, so autoTitleForCurrentTurn (which skips
+  // when the current title is not a default browser title) yields nothing and
+  // the session is named exactly once, at birth.
+  const autoTitle = source.match(/function autoTitleForCurrentTurn\(userText = ''\) \{[\s\S]*?\n\}/)?.[0] || '';
+  assert.match(autoTitle, /if \(!isDefaultBrowserSessionTitle\(currentTitle\)\) return '';/);
+  assert.match(autoTitle, /return autoSessionTitleFromText\(userText\);/);
+});

--- a/tests/context-menu.test.mjs
+++ b/tests/context-menu.test.mjs
@@ -1,0 +1,150 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CONTEXT_MENU_MAX_ITEMS,
+  CONTEXT_MENU_MAX_PROMPT_LENGTH,
+  CONTEXT_MENU_MAX_TITLE_LENGTH,
+  DEFAULT_CONTEXT_MENU_ITEMS,
+  cloneDefaultContextMenuItems,
+  normalizeContextMenuItem,
+  normalizeContextMenuItems,
+} from '../extension/lib/common.mjs';
+
+test('context menu: missing settings fall back to deep-cloned defaults', () => {
+  const items = normalizeContextMenuItems(undefined);
+  assert.equal(items.length, DEFAULT_CONTEXT_MENU_ITEMS.length);
+  items[0].contexts.push('page');
+  items[0].title = 'changed';
+  assert.deepEqual(DEFAULT_CONTEXT_MENU_ITEMS[0].contexts, ['selection'], 'defaults must not be mutated by fallback copies');
+  assert.equal(DEFAULT_CONTEXT_MENU_ITEMS[0].title, 'Ask Hermes about this selection');
+});
+
+test('context menu: an explicit empty list stays empty', () => {
+  assert.deepEqual(normalizeContextMenuItems([]), []);
+});
+
+test('context menu: clearing the final title yields an empty list, not the defaults', () => {
+  const items = normalizeContextMenuItems([{ id: 'a', title: '   ', contexts: ['selection'] }]);
+  assert.deepEqual(items, []);
+});
+
+test('context menu: an entirely invalid list yields an empty list, not the defaults', () => {
+  const items = normalizeContextMenuItems([{ id: 'a', title: '', contexts: ['selection'] }]);
+  assert.deepEqual(items, []);
+});
+
+test('context menu: disabled-only lists are preserved', () => {
+  const items = normalizeContextMenuItems([{ id: 'a', title: 'A', contexts: ['selection'], enabled: false }]);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].enabled, false);
+});
+
+test('context menu: blank titles are dropped', () => {
+  const items = normalizeContextMenuItems([
+    { id: 'a', title: '   ', contexts: ['selection'] },
+    { id: 'b', title: 'Real', contexts: ['selection'] },
+  ]);
+  assert.deepEqual(items.map((item) => item.id), ['b']);
+});
+
+test('context menu: items with zero valid contexts are dropped', () => {
+  const items = normalizeContextMenuItems([
+    { id: 'a', title: 'A', contexts: [] },
+    { id: 'b', title: 'B', contexts: ['nonsense'] },
+    { id: 'c', title: 'C', contexts: ['selection'] },
+  ]);
+  assert.deepEqual(items.map((item) => item.id), ['c']);
+});
+
+test('context menu: duplicate item ids are deduplicated keeping the first', () => {
+  const items = normalizeContextMenuItems([
+    { id: 'a', title: 'First', contexts: ['selection'] },
+    { id: 'a', title: 'Second', contexts: ['page'] },
+    { id: 'b', title: 'B', contexts: ['selection'] },
+  ]);
+  assert.deepEqual(items.map((item) => item.title), ['First', 'B']);
+});
+
+test('context menu: duplicate contexts are deduplicated', () => {
+  const item = normalizeContextMenuItem({ id: 'a', title: 'A', contexts: ['selection', 'selection', 'editable'] });
+  assert.deepEqual(item.contexts, ['selection', 'editable']);
+});
+
+test('context menu: unknown inline actions are rejected', () => {
+  assert.equal(normalizeContextMenuItem({ id: 'a', title: 'A', contexts: ['editable'], inlineAction: 'teleport' }), null);
+});
+
+test('context menu: allowlisted inline actions are accepted', () => {
+  const item = normalizeContextMenuItem({ id: 'a', title: 'A', contexts: ['editable'], inlineAction: 'improve' });
+  assert.equal(item.inlineAction, 'improve');
+  assert.deepEqual(item.contexts, ['editable']);
+});
+
+test('context menu: prompt items are restricted to selection and editable contexts', () => {
+  const item = normalizeContextMenuItem({ id: 'a', title: 'A', contexts: ['page', 'link', 'selection'], prompt: 'Ask' });
+  assert.deepEqual(item.contexts, ['selection']);
+  const pageOnly = normalizeContextMenuItem({ id: 'b', title: 'B', contexts: ['page'], prompt: 'Ask' });
+  assert.equal(pageOnly, null);
+});
+
+test('context menu: inline items are restricted to editable contexts', () => {
+  const item = normalizeContextMenuItem({ id: 'a', title: 'A', contexts: ['selection', 'editable', 'image'], inlineAction: 'improve' });
+  assert.deepEqual(item.contexts, ['editable']);
+  const nonEditable = normalizeContextMenuItem({ id: 'b', title: 'B', contexts: ['selection'], inlineAction: 'improve' });
+  assert.equal(nonEditable, null);
+});
+
+test('context menu: the default open item normalizes as an explicit open action', () => {
+  const item = normalizeContextMenuItem(DEFAULT_CONTEXT_MENU_ITEMS[5]);
+  assert.equal(item.open, true);
+  assert.deepEqual(item.contexts, ['page', 'link', 'image', 'video', 'audio']);
+});
+
+test('context menu: explicit open flag and open mode are honored for custom ids', () => {
+  const flagged = normalizeContextMenuItem({ id: 'custom-open', title: 'Open', contexts: ['page'], open: true });
+  assert.equal(flagged.open, true);
+  const byMode = normalizeContextMenuItem({ id: 'custom-open-2', title: 'Open', contexts: ['page'], mode: 'open' });
+  assert.equal(byMode.open, true);
+});
+
+test('context menu: item count is bounded', () => {
+  const many = Array.from({ length: CONTEXT_MENU_MAX_ITEMS + 5 }, (_, i) => ({ id: `item-${i}`, title: `Item ${i}`, contexts: ['selection'] }));
+  const items = normalizeContextMenuItems(many);
+  assert.equal(items.length, CONTEXT_MENU_MAX_ITEMS);
+});
+
+test('context menu: overlong titles and prompts are truncated', () => {
+  const item = normalizeContextMenuItem({
+    id: 'a',
+    title: 'x'.repeat(CONTEXT_MENU_MAX_TITLE_LENGTH + 20),
+    contexts: ['selection'],
+    prompt: 'p'.repeat(CONTEXT_MENU_MAX_PROMPT_LENGTH + 20),
+  });
+  assert.equal(item.title.length, CONTEXT_MENU_MAX_TITLE_LENGTH);
+  assert.equal(item.prompt.length, CONTEXT_MENU_MAX_PROMPT_LENGTH);
+});
+
+test('context menu: non-array garbage falls back to defaults', () => {
+  for (const garbage of [null, 'text', { id: 'a' }, 42]) {
+    const items = normalizeContextMenuItems(garbage);
+    assert.equal(items.length, DEFAULT_CONTEXT_MENU_ITEMS.length);
+  }
+});
+
+test('context menu: invalid entries are dropped while valid entries survive', () => {
+  const items = normalizeContextMenuItems([
+    null,
+    'text',
+    { id: 'a', title: 'A', contexts: ['selection'] },
+    { id: '', title: 'No id', contexts: ['selection'] },
+  ]);
+  assert.deepEqual(items.map((item) => item.id), ['a']);
+});
+
+test('context menu: cloneDefaultContextMenuItems produces independent nested arrays', () => {
+  const first = cloneDefaultContextMenuItems();
+  const second = cloneDefaultContextMenuItems();
+  first[0].contexts.push('editable');
+  assert.deepEqual(second[0].contexts, ['selection']);
+  assert.deepEqual(DEFAULT_CONTEXT_MENU_ITEMS[0].contexts, ['selection']);
+});

--- a/tests/context-menu.test.mjs
+++ b/tests/context-menu.test.mjs
@@ -80,11 +80,12 @@ test('context menu: allowlisted inline actions are accepted', () => {
   assert.deepEqual(item.contexts, ['editable']);
 });
 
-test('context menu: prompt items are restricted to selection and editable contexts', () => {
-  const item = normalizeContextMenuItem({ id: 'a', title: 'A', contexts: ['page', 'link', 'selection'], prompt: 'Ask' });
-  assert.deepEqual(item.contexts, ['selection']);
-  const pageOnly = normalizeContextMenuItem({ id: 'b', title: 'B', contexts: ['page'], prompt: 'Ask' });
-  assert.equal(pageOnly, null);
+test('context menu: prompt items keep every context', () => {
+  const item = normalizeContextMenuItem({ id: 'a', title: 'A', contexts: ['page', 'link', 'image', 'video', 'audio', 'selection', 'editable'], prompt: 'Ask' });
+  assert.deepEqual(item.contexts, ['page', 'link', 'image', 'video', 'audio', 'selection', 'editable']);
+  const pageOnly = normalizeContextMenuItem({ id: 'b', title: 'B', contexts: ['page'], prompt: 'Run /ingest for this page' });
+  assert.equal(pageOnly.prompt, 'Run /ingest for this page');
+  assert.deepEqual(pageOnly.contexts, ['page']);
 });
 
 test('context menu: inline items are restricted to editable contexts', () => {

--- a/tests/inline-draft-runtime.test.mjs
+++ b/tests/inline-draft-runtime.test.mjs
@@ -120,6 +120,7 @@ test('Sidecar intro is panel-open-only and new session cannot reveal it again', 
 
 test('background queues sender-bound requests, exposes session status, and registers branded context menus', async () => {
   const source = await read('extension/background.js');
+  const commonSource = await read('extension/lib/common.mjs');
   const [packaged, repository] = await Promise.all([
     read('extension/manifest.json').then(JSON.parse),
     read('manifest.json').then(JSON.parse),
@@ -146,12 +147,12 @@ test('background queues sender-bound requests, exposes session status, and regis
   assert.match(source, /openHermesPanel\(sender\.tab\)/);
   assert.match(source, /expiresAt/);
   assert.match(source, /chrome\.contextMenus\.create/);
-  assert.match(source, /Ask Hermes about this selection/);
-  assert.match(source, /Improve selected text/);
+  assert.match(commonSource, /Ask Hermes about this selection/);
+  assert.match(commonSource, /Improve selected text/);
   assert.match(source, /openHermesPanel\(tab, \{ allowFallback: false \}\)/);
   assert.match(source, /Strict side-panel open failed; refusing to open a fallback tab/);
   assert.match(source, /contextMenuDefaultRoute/);
-  assert.match(source, /Explain selection/);
+  assert.match(commonSource, /Explain selection/);
   assert.ok(packaged.permissions.includes('contextMenus'));
   assert.ok(repository.permissions.includes('contextMenus'));
 });


### PR DESCRIPTION
Resolves #56

Currently, the right-click context menu items (Ask, Summarize, Explain, Improve, Draft Reply, Open Hermes) are hardcoded in background.js. Users cannot add, remove, reorder, toggle, or edit these items from the UI.

This PR adds full user control over context menu items from the settings panel in both the side panel and Hermes Web surfaces, and fixes two real-test findings from the right-click behaviour spike that blocked the workflow.

## Part 1 — User-editable context menu items

- Move context menu item definitions to settings (chrome.storage.local)
- Add `contextMenuItems`, `DEFAULT_CONTEXT_MENU_ITEMS`, `normalizeContextMenuItems`, `INLINE_CONTEXT_ACTIONS`, `CONTEXT_MENU_CONTEXTS`, and `normalizeContextMenuItem` to common.mjs
- background.js reads items from settings and rebuilds menus on storage change via the storage.onChanged listener
- Settings UI: list editor with toggle, edit label, edit prompt, reorder (up/down), add, remove
- Each item supports: enabled/disabled, title, contexts (selection/editable/page/link/image/video/audio), and either a prompt (sent to gateway) or an inline action
- CSS uses real design tokens (--hermes-line, --hermes-ink-rgb, --hermes-muted) with responsive flex-wrap layout for narrow side panel
- Test updated to read from common.mjs instead of background.js for moved strings

Files changed: 9 (562 insertions, 15 deletions)

## Part 2 — Right-click reliability fixes (from spike)

Three commits validated against real Chrome:

### `1fb6330` — Summon the side panel inside the context-menu user gesture
The earlier builds fell back to a tab with `sidePanel.open() may only be called in response to a user gesture`. The sync open now happens inside the gesture, before any awaited API. If the sync open rejects (panel not yet enabled for the tab), the async path re-applies residency and only then opens a fallback tab.

### `71e4c9e` — Title right-click new sessions from the task at creation
Right-click new sessions kept the default "Hermes Browser Extension" name because the post-turn auto-title is gated by `autoNameSessions`, `apiKey`, and remote-dashboard rename support. Sessions are now titled at birth from the task text (`autoSessionTitleFromText`), mode-agnostic, named exactly once. The derived title also makes the post-turn auto-title logic skip (title is no longer default).

### `c76826a` — Right-click tasks attach browser context instead of forcing chat-only
Every right-click `askHermes` call set `forceChatOnly: true`, which forced `refreshContext()` to skip and nulled the browser context — the panel showed "Chat only — no browser context attached" for every right-click task, regardless of the user's context scope setting. Removing `forceChatOnly` lets `askHermes` call `refreshContext()`, which honors the user's context scope (follow-active, pinned-tab) and the control-panel Page context depth setting (`contextDepth`). Page content now arrives through the normal `browser_context` attachment — the same pipeline the composer uses.

The `contextMenuPageText` helper (added in `71e4c9e` to fold page text into the prompt body) is removed because it duplicated `refreshContext`: it captured page text but `forceChatOnly` still nulled the structured context. With `forceChatOnly` gone, `refreshContext` does the work properly.

## Testing

- 661 tests pass (`npm run test`)
- 0 lint errors (`npm run lint`) — 12 pre-existing warnings untouched
- Build succeeds (`npm run build`)
- Manual recipe in `spikes/manual-test-recipe.md` covers the live-Chrome pass