### PR TITLE
Add MiniMax-M2.7 context fallback

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -1229,6 +1229,8 @@ const MODEL_CONTEXT_FALLBACKS = Object.freeze([
   ['qwen', 131_072],
   ['minimax-m3', 1_000_000],
   ['minimax/m3', 1_000_000],
+  ['minimax-m2.7', 204_800],
+  ['minimax/m2.7', 204_800],
   ['minimax', 204_800],
   ['glm-5.2', 1_048_576],
   ['glm', 202_752],

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -1608,9 +1608,16 @@ test('normalizeHermesModels does not keep default hermes-agent fallback when rea
   assert.deepEqual(models.map((model) => model.id), ['openai-codex:gpt-5.5']);
 });
 
-test('normalizeHermesModels applies curated context fallback when provider rows omit limits', () => {
-  const models = normalizeHermesModels({ data: [{ id: 'minimax:MiniMax-M3', name: 'MiniMax-M3', context_length: 0 }] }, 'minimax:MiniMax-M3');
-  assert.equal(models[0].contextTokens, 1000000);
+test('normalizeHermesModels applies explicit MiniMax context fallbacks when provider rows omit limits', () => {
+  const m3Models = normalizeHermesModels({ data: [{ id: 'minimax:MiniMax-M3', name: 'MiniMax-M3', context_length: 0 }] }, 'minimax:MiniMax-M3');
+  assert.equal(m3Models[0].contextTokens, 1_000_000);
+
+  const m27Models = normalizeHermesModels({ data: [{ id: 'minimax:MiniMax-M2.7', name: 'MiniMax-M2.7', context_length: 0 }] }, 'minimax:MiniMax-M2.7');
+  assert.equal(m27Models[0].contextTokens, 204_800);
+
+  const source = readFileSync(new URL('../extension/lib/common.mjs', import.meta.url), 'utf8');
+  assert.match(source, /\['minimax-m2\.7',\s*204_800\]/);
+  assert.match(source, /\['minimax\/m2\.7',\s*204_800\]/);
 });
 
 test('normalizeHermesModels applies 1M context fallback for Qwen Token Plan models', () => {


### PR DESCRIPTION
Reason: Add explicit MiniMax-M2.7 context fallback metadata so model discovery reports its 204800-token window without relying on the provider catch-all.

- Add explicit hyphenated and slash-form fallback aliases for MiniMax-M2.7.
- Extend the context fallback regression test to cover the model and its explicit entries.

Checks:
- `node --test tests/common.test.mjs`
- `PYTHON=python3 npm run verify`
- `npm run lint`
