### PR TITLE
fix: recover dashboard transport after clearing API token

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -132,6 +132,10 @@ export function normalizeGatewayMode(value = DEFAULT_SETTINGS.gatewayMode) {
   return GATEWAY_MODES.some((mode) => mode.value === normalized) ? normalized : DEFAULT_SETTINGS.gatewayMode;
 }
 
+export function gatewayModeAfterTokenClear(value = DEFAULT_SETTINGS.gatewayMode) {
+  return normalizeGatewayMode(value) === 'local-api' ? 'local-api' : 'remote-dashboard';
+}
+
 export function normalizeSessionStartupMode(value = DEFAULT_SETTINGS.sessionStartupMode) {
   const normalized = String(value || DEFAULT_SETTINGS.sessionStartupMode).trim().toLowerCase();
   return normalized === 'resume-last' ? 'resume-last' : 'new-session';

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -26,6 +26,7 @@ import {
   escapeHtml,
   extractAssistantText,
   formatUpdateStatus,
+  gatewayModeAfterTokenClear,
   gatewayConnectionTroubleshooting,
   gatewayConnectionSummary,
   groupModelsForMenu,
@@ -3975,14 +3976,21 @@ async function saveSettingsFromForm() {
 }
 
 async function clearStoredToken() {
-  settings = { ...settings, apiKey: '', tokenSource: '', lastConnectionTestedAt: 0 };
+  const gatewayMode = gatewayModeAfterTokenClear(settings.gatewayMode);
+  settings = { ...settings, gatewayMode, apiKey: '', tokenSource: '', lastConnectionTestedAt: 0 };
   await chrome.storage.local.set({ hermesBrowserSettings: settings });
   if (els.apiKeyInput) els.apiKeyInput.value = '';
   sessionRoutesAvailable = null;
-  markConnectionProbe('unconfigured', 'Token cleared by user.');
+  markConnectionProbe(gatewayMode === 'remote-dashboard' ? 'connecting' : 'unconfigured', 'Token cleared by user.');
   setGatewayCapabilities(normalizeGatewayCapabilities(null, { healthOk: false, hasApiKey: false, warning: 'Token cleared; reconnect to refresh capabilities.' }));
   syncSettingsForm();
-  setStatus('warn', 'Hermes token cleared', 'Paste a Gateway API key or reconnect when you are ready.');
+  setStatus(
+    gatewayMode === 'remote-dashboard' ? 'ok' : 'warn',
+    'Hermes token cleared',
+    gatewayMode === 'remote-dashboard'
+      ? 'Remote dashboard WebSocket mode selected. Keep the dashboard open and signed in, then reconnect.'
+      : 'Paste a Gateway API key or reconnect when you are ready.',
+  );
 }
 
 async function activeTab() {
@@ -5722,13 +5730,16 @@ async function runStartupReadiness() {
     renderStartupReadiness();
 
     setStartupReadiness({ phase: 'gateway-probe', step: 'gateway', status: 'active', detail: `Checking ${normalizeGatewayUrl(settings.gatewayUrl)}…` });
+    if (isRemoteWsMode()) await ensureRemoteWsClient();
     const state = await probeGatewayLiveness({ quiet: true });
-    if (!settings.apiKey || !state.connected) {
-      const missingToken = !settings.apiKey;
+    const gatewayReady = state.connected || (isRemoteWsMode() && remoteWsConnection?.client?.readyState === 1);
+    if (!gatewayReady) {
       setStartupReadiness({
         step: 'gateway',
-        status: missingToken ? 'unconfigured' : (state.state === 'unreachable' ? 'unreachable' : 'error'),
-        detail: missingToken ? 'Add a Hermes API token or complete pairing to use full Hermes Browser mode.' : currentConnectionTroubleshooting(state),
+        status: state.state === 'unconfigured' ? 'unconfigured' : (state.state === 'unreachable' ? 'unreachable' : 'error'),
+        detail: state.state === 'unconfigured'
+          ? (isRemoteWsMode() ? 'Set a remote https dashboard URL in Settings and sign in to that dashboard in a browser tab.' : 'Add a Hermes API token or complete pairing to use full Hermes Browser mode.')
+          : currentConnectionTroubleshooting(state),
       });
       renderModelOptions();
       renderSessionMenu();

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -28,6 +28,7 @@ import {
   estimateContextWindow,
   extractAssistantText,
   formatContextMeter,
+  gatewayModeAfterTokenClear,
   gatewayConnectionTroubleshooting,
   gatewayConnectionSummary,
   isUsableRemoteGatewayUrl,
@@ -379,6 +380,12 @@ test('gateway settings support explicit local and remote Hermes API servers', ()
   assert.match(dashboard.title, /Remote Hermes dashboard/);
   assert.match(dashboard.setupHint, /WebSocket/);
   assert.match(dashboard.setupHint, /sign in/i);
+});
+
+test('clearing a remote API token switches transport to dashboard WebSocket mode', () => {
+  assert.equal(gatewayModeAfterTokenClear('remote-api'), 'remote-dashboard');
+  assert.equal(gatewayModeAfterTokenClear('remote-dashboard'), 'remote-dashboard');
+  assert.equal(gatewayModeAfterTokenClear('local-api'), 'local-api');
 });
 
 test('isUsableRemoteGatewayUrl requires a parseable https URL', () => {


### PR DESCRIPTION
## Summary
- switch a remote connection from remote-api to remote-dashboard when its stored token is cleared
- initialize dashboard WebSocket during startup readiness instead of treating a blank token as unconfigured
- add regression coverage for transport selection after token removal

## Root cause
Clear stored token removed the API key but retained gatewayMode=remote-api. The next probe therefore emitted Remote Hermes API is not reachable for a dashboard URL and never attempted ws-ticket/WebSocket transport.

## Verification
- npm run verify: 184 tests passed
- npm run package: extension archive built