### PR TITLE
Fix Browser Dashboard Attach profile selection (remote-dashboard)

### DIFF
--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -132,6 +132,22 @@ export function normalizeGatewayMode(value = DEFAULT_SETTINGS.gatewayMode) {
   return GATEWAY_MODES.some((mode) => mode.value === normalized) ? normalized : DEFAULT_SETTINGS.gatewayMode;
 }
 
+// The "Connected agent" port scanner (localhost 8642-8646 sidecar probe) only
+// applies to the local/remote API-server transports. In remote-dashboard mode
+// the transport is the dashboard WebSocket on 443, so the probe is meaningless
+// and would falsely report "no agents online", implying Dashboard Attach is
+// down. Gate it behind this so UI never implies a false offline state.
+export function agentDiscoveryAppliesToMode(value = DEFAULT_SETTINGS.gatewayMode) {
+  return normalizeGatewayMode(value) !== 'remote-dashboard';
+}
+
+export function agentDiscoveryModeNote(value = DEFAULT_SETTINGS.gatewayMode) {
+  if (agentDiscoveryAppliesToMode(value)) {
+    return 'Scans a trusted Hermes API host for running sidecar gateways.';
+  }
+  return 'Sidecar scan is skipped in Remote dashboard mode. Dashboard Attach connects over the dashboard WebSocket (port 443); this scanner only finds local/sidecar API servers on 8642-8646. Dashboard Attach status is shown by the connection indicator, not here.';
+}
+
 export function normalizeSessionStartupMode(value = DEFAULT_SETTINGS.sessionStartupMode) {
   const normalized = String(value || DEFAULT_SETTINGS.sessionStartupMode).trim().toLowerCase();
   return normalized === 'resume-last' ? 'resume-last' : 'new-session';

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -1775,3 +1775,37 @@ export function shouldStopSessionPaging({ rowCount = 0, offset = 0, total = 0, h
   if (total && offset < total) return false;
   return true;
 }
+
+// ---------------------------------------------------------------------------
+// Profile-bound session identity.
+//
+// A stored session binding records the gateway + profile it belongs to. Resume
+// must never cross profile boundaries: if the user selected a different profile
+// (or deselected one) since the binding was written, the binding is stale and
+// must be invalidated instead of silently resuming the wrong profile's chat.
+// ---------------------------------------------------------------------------
+
+export function sessionBindingIdentity({ gatewayUrl = '', profile = '', gatewayMode = '' } = {}) {
+  return {
+    gatewayUrl: normalizeGatewayUrl(gatewayUrl || ''),
+    gatewayMode: normalizeGatewayMode(gatewayMode || ''),
+    profile: String(profile || '').trim(),
+  };
+}
+
+// Compare a stored binding's identity against the current connection identity.
+// Returns true when the binding was created for the same gateway + profile.
+export function isSessionBindingValid(binding = null, currentIdentity = {}) {
+  if (!binding || typeof binding !== 'object') return false;
+  const prev = binding.identity || {};
+  const next = currentIdentity || {};
+  if (normalizeGatewayUrl(prev.gatewayUrl || '') !== normalizeGatewayUrl(next.gatewayUrl || '')) return false;
+  if (normalizeGatewayMode(prev.gatewayMode || '') !== normalizeGatewayMode(next.gatewayMode || '')) return false;
+  if (String(prev.profile || '').trim() !== String(next.profile || '').trim()) return false;
+  return true;
+}
+
+// Attach the identity to a binding before persisting it.
+export function withSessionBindingIdentity(binding = {}, currentIdentity = {}) {
+  return { ...(binding || {}), identity: { ...currentIdentity } };
+}

--- a/extension/lib/dashboard-bridge.mjs
+++ b/extension/lib/dashboard-bridge.mjs
@@ -112,3 +112,143 @@ export function ticketFailureHelp(reason = '', origin = '') {
       return `Could not get a dashboard WebSocket ticket (${reason || 'unknown'}).`;
   }
 }
+
+// ---------------------------------------------------------------------------
+// First-party profile discovery for remote-dashboard mode.
+//
+// The dashboard's REST surface (including /api/profiles) is CORS-blocked from
+// the extension origin, so the request must run INSIDE a signed-in dashboard
+// tab via chrome.scripting  same as ws-ticket minting. There the fetch is
+// first-party (same-origin cookie rides) and the dashboard session token in
+// the page bootstraps the authenticated /api/profiles call.
+//
+// The in-page function (discoverProfilesInPage) must stay self-contained:
+// chrome.scripting serializes it and runs it in the page, so it cannot close
+// over module scope.
+// ---------------------------------------------------------------------------
+
+export function dashboardProfilesUrl(baseUrl = '', profile = '') {
+  try {
+    const url = new URL(String(baseUrl || '').trim());
+    url.hash = '';
+    url.search = '';
+    const profileName = String(profile || '').trim();
+    if (profileName) url.searchParams.set('profile', profileName);
+    url.pathname = `${url.pathname.replace(/\/+$/, '')}/api/profiles`;
+    return url.toString();
+  } catch {
+    const params = new URLSearchParams();
+    const profileName = String(profile || '').trim();
+    if (profileName) params.set('profile', profileName);
+    const suffix = params.toString() ? `?${params.toString()}` : '';
+    return `${String(baseUrl || '').replace(/\/+$/, '')}/api/profiles${suffix}`;
+  }
+}
+
+// Runs in the dashboard page. Mirrors discoverModelsFromDashboard's token
+// bootstrap but reads the profile roster instead of model options. Returns a
+// structured result so the caller can branch on `reason`.
+export async function discoverProfilesInPage(baseUrl, profile = '') {
+  try {
+    const rootUrl = String(baseUrl || '').trim().replace(/\/+$/, '');
+    const rootResponse = await fetch(rootUrl, {
+      method: 'GET',
+      headers: { Accept: 'text/html' },
+      credentials: 'include',
+    });
+    if (!rootResponse.ok) return { ok: false, reason: `dashboard_root_${rootResponse.status}` };
+    const html = await rootResponse.text();
+    const match = html.match(/window\.__HERMES_SESSION_TOKEN__\s*=\s*"([^"]+)"/);
+    const token = match?.[1] || '';
+    if (!token) return { ok: false, reason: 'no_dashboard_session_token' };
+
+    const response = await fetch(dashboardProfilesUrl(baseUrl, profile), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'X-Hermes-Session-Token': token,
+      },
+      credentials: 'include',
+    });
+    if (response.status === 401 || response.status === 403) {
+      return { ok: false, reason: 'not_signed_in', status: response.status };
+    }
+    if (!response.ok) return { ok: false, reason: `profiles_http_${response.status}`, status: response.status };
+    const data = await response.json().catch(() => null);
+    if (!data || !Array.isArray(data.profiles)) return { ok: false, reason: 'no_profiles_in_response' };
+    return { ok: true, profiles: data.profiles };
+  } catch (error) {
+    return { ok: false, reason: 'fetch_failed', detail: String(error?.message || error) };
+  }
+}
+
+// Discover profiles by executing the discovery inside a logged-in dashboard
+// tab. Returns the discoverProfilesInPage result shape, plus
+// { ok:false, reason:'no_dashboard_tab', origin } when no usable tab exists.
+export async function discoverProfilesViaTab({ tabsApi, scriptingApi, baseUrl, profile = '', discoverFn = discoverProfilesInPage }) {
+  const origin = originOf(baseUrl);
+  if (!origin) return { ok: false, reason: 'bad_base_url' };
+  if (!scriptingApi?.executeScript) return { ok: false, reason: 'scripting_unavailable' };
+
+  const tab = await findDashboardTab(tabsApi, origin);
+  if (!tab?.id) return { ok: false, reason: 'no_dashboard_tab', origin };
+
+  let injection;
+  try {
+    [injection] = await scriptingApi.executeScript({
+      target: { tabId: tab.id },
+      func: discoverFn,
+      args: [baseUrl, profile],
+    });
+  } catch (error) {
+    return { ok: false, reason: 'inject_failed', detail: String(error?.message || error) };
+  }
+  return injection?.result || { ok: false, reason: 'no_result' };
+}
+
+// fetchFn-based discovery (no scripting) for unit tests and the local-dashboard
+// scraping fallback. Mirrors discoverModelsFromDashboard's token bootstrap.
+export async function discoverProfilesFromDashboard({ baseUrl = '', fetchFn = globalThis.fetch?.bind(globalThis), profile = '' } = {}) {
+  const dashboardUrl = String(baseUrl || '').trim();
+  if (!dashboardUrl) return { ok: false, error: 'no-dashboard-url', profiles: [] };
+  if (typeof fetchFn !== 'function') return { ok: false, error: 'no-fetch', profiles: [] };
+  try {
+    const rootResponse = await fetchFn(dashboardUrl, {
+      method: 'GET',
+      headers: { Accept: 'text/html' },
+      credentials: 'include',
+    });
+    if (!rootResponse.ok) return { ok: false, error: `dashboard-root-${rootResponse.status}`, profiles: [] };
+    const html = await rootResponse.text();
+    const match = html.match(/window\.__HERMES_SESSION_TOKEN__\s*=\s*"([^"]+)"/);
+    const token = match?.[1] || '';
+    if (!token) return { ok: false, error: 'no-dashboard-session-token', profiles: [] };
+
+    const optionsResponse = await fetchFn(dashboardProfilesUrl(dashboardUrl, profile), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'X-Hermes-Session-Token': token,
+      },
+      credentials: 'include',
+    });
+    const text = await optionsResponse.text();
+    let payload = null;
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = { error: text.slice(0, 500) };
+    }
+    if (!optionsResponse.ok) {
+      return {
+        ok: false,
+        error: payload?.detail || payload?.error?.message || payload?.error || `dashboard-profiles-${optionsResponse.status}`,
+        profiles: [],
+      };
+    }
+    if (!payload || !Array.isArray(payload.profiles)) return { ok: false, error: 'no-profiles-in-response', profiles: [] };
+    return { ok: true, profiles: payload.profiles, error: '' };
+  } catch (error) {
+    return { ok: false, error: error?.name === 'AbortError' ? 'dashboard-timeout' : (error?.message || 'error'), profiles: [] };
+  }
+}

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -231,8 +231,11 @@
           <section class="settings-section">
             <h3>Connected agent</h3>
             <p class="hint">
-              Scans a trusted Hermes API host for running gateways. Use localhost for
-              same-machine agents, or a Tailscale host/IP for private remote agents.
+              Scans a trusted Hermes API host for running sidecar gateways on
+              8642-8646. This is for Local/Remote API mode only. In Remote
+              dashboard mode Dashboard Attach connects over the dashboard
+              WebSocket (port 443), so this scan is skipped and its status
+              never reflects Dashboard Attach availability.
             </p>
             <div id="agentList" class="agent-list" role="list" aria-label="Discovered Hermes agents"></div>
             <div class="settings-row">

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -66,6 +66,8 @@ import {
   sessionBindingIdentity,
   isSessionBindingValid,
   withSessionBindingIdentity,
+  agentDiscoveryAppliesToMode,
+  agentDiscoveryModeNote,
 } from './lib/common.mjs';
 import { extractYouTubeVideoId } from './lib/transcript.mjs';
 import { buildDashboardWsUrl, createGatewayClient, WS_EVENTS, WS_METHODS } from './lib/gateway-ws.mjs';
@@ -460,6 +462,22 @@ function renderGatewayHelp() {
   });
   if (els.gatewayHelp) els.gatewayHelp.textContent = summary.setupHint;
   if (els.gatewayUrlInput) els.gatewayUrlInput.placeholder = summary.mode.defaultUrl || DEFAULT_SETTINGS.gatewayUrl;
+}
+
+// The "Connected agent" port scanner is meaningless in remote-dashboard mode
+// (transport is the dashboard WebSocket on 443, not a local sidecar on
+// 8642-8646). Disable the scanner controls there so they can't imply
+// Dashboard Attach is offline, and surface a clear non-blocking note.
+function renderAgentDiscoveryAvailability() {
+  const applicable = agentDiscoveryAppliesToMode(els.gatewayModeInput?.value || settings.gatewayMode);
+  for (const control of [els.refreshAgentsButton, els.addCustomAgentButton, els.agentHostInput, els.agentSchemeInput, els.agentPortsInput]) {
+    if (control && 'disabled' in control) control.disabled = !applicable;
+  }
+  if (els.agentPickerStatus) {
+    els.agentPickerStatus.textContent = applicable
+      ? 'Agent discovery has not run yet.'
+      : agentDiscoveryModeNote(els.gatewayModeInput?.value || settings.gatewayMode);
+  }
 }
 
 function remoteEnvBlockText() {
@@ -3360,6 +3378,17 @@ function renderAgentList(agents = discoveredAgents) {
 
 async function loadAgents({ quiet = false } = {}) {
   if (!els.agentList) return;
+  // In remote-dashboard mode the transport is the dashboard WebSocket (443),
+  // not a local sidecar on 8642-8646. The port probe is meaningless here and
+  // would falsely report "no agents online", implying Dashboard Attach is down.
+  // Skip it and let the connection indicator own the status.
+  if (isRemoteWsMode()) {
+    els.agentList.innerHTML = '<p class="hint">Sidecar agent scan is skipped in Remote dashboard mode. Dashboard Attach connects over the dashboard WebSocket (port 443); use the connection indicator for live status.</p>';
+    if (els.agentPickerStatus) {
+      els.agentPickerStatus.textContent = 'Skipped: remote dashboard mode uses the dashboard WebSocket, not a local sidecar.';
+    }
+    return;
+  }
   const ports = getAgentPorts();
   if (!ports.length) {
     els.agentList.innerHTML = '<p class="hint">No agent ports configured. Set ports in the field below.</p>';
@@ -4005,6 +4034,7 @@ function syncSettingsForm() {
   els.gatewayUrlInput.value = settings.gatewayUrl;
   renderGatewayHelp();
   renderGatewayModeCards();
+  renderAgentDiscoveryAvailability();
   els.apiKeyInput.value = settings.apiKey || '';
   els.sessionIdInput.value = settings.sessionId;
   els.sessionTitleInput.value = settings.sessionTitle;
@@ -5576,6 +5606,7 @@ function bindEvents() {
       els.gatewayUrlInput.value = summary.mode.defaultUrl || DEFAULT_SETTINGS.gatewayUrl;
     }
     renderGatewayHelp();
+    renderAgentDiscoveryAvailability();
   });
   els.gatewayUrlInput?.addEventListener('input', renderGatewayHelp);
   for (const card of document.querySelectorAll('[data-gateway-location]')) {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -63,10 +63,13 @@ import {
   shouldAutoFlushQueuedTurn,
   shouldCreateFreshSessionOnOpen,
   skillSuggestionsForInput,
+  sessionBindingIdentity,
+  isSessionBindingValid,
+  withSessionBindingIdentity,
 } from './lib/common.mjs';
 import { extractYouTubeVideoId } from './lib/transcript.mjs';
 import { buildDashboardWsUrl, createGatewayClient, WS_EVENTS, WS_METHODS } from './lib/gateway-ws.mjs';
-import { mintWsTicket, ticketFailureHelp } from './lib/dashboard-bridge.mjs';
+import { mintWsTicket, ticketFailureHelp, discoverProfilesViaTab } from './lib/dashboard-bridge.mjs';
 import {
   deriveStartupView,
   initialStartupReadiness,
@@ -724,15 +727,22 @@ async function loadSessionBindingForActiveScope() {
 async function saveSessionBindingForActiveScope(session) {
   if (previousConversationScope.mode !== CONTEXT_SCOPE_MODES.PINNED_TAB || !session?.id) return;
   const key = sessionBindingKeyForScope(contextScope, previousConversationScope);
+  // Bind the stored session to the gateway + profile that created it so resume
+  // cannot silently cross profile boundaries if the user switches profiles.
+  const identity = sessionBindingIdentity({
+    gatewayUrl: normalizeGatewayUrl(settings.gatewayUrl),
+    gatewayMode: settings.gatewayMode,
+    profile: safeActiveProfile(),
+  });
   await chrome.storage.local.set({
-    [key]: {
+    [key]: withSessionBindingIdentity({
       sessionId: session.id,
       sessionTitle: session.title || session.id,
       pinnedTabId: previousConversationScope.pinnedTabId,
       pinnedTitle: previousConversationScope.pinnedTitle || '',
       pinnedUrl: previousConversationScope.pinnedUrl || '',
       updatedAt: Date.now(),
-    },
+    }, identity),
   });
 }
 
@@ -1000,14 +1010,29 @@ async function ensureSessionForActiveScope({ focus = false } = {}) {
   }
   if (!settings.apiKey || !isConnected()) return;
   const binding = await loadSessionBindingForActiveScope();
+  // Never resume a stored session under a different gateway + profile than the
+  // one that created it. A mismatched binding is stale; drop it and start fresh
+  // so the user's Chat-only history never silently crosses into another profile.
   if (binding?.sessionId) {
-    const session = availableSessions.find((item) => item.id === binding.sessionId) || {
-      id: binding.sessionId,
-      title: binding.sessionTitle || binding.sessionId,
-      source: DEFAULT_SETTINGS.sessionSource,
-    };
-    await openHermesSession(session);
-    return;
+    const currentIdentity = sessionBindingIdentity({
+      gatewayUrl: normalizeGatewayUrl(settings.gatewayUrl),
+      gatewayMode: settings.gatewayMode,
+      profile: safeActiveProfile(),
+    });
+    if (isSessionBindingValid(binding, currentIdentity)) {
+      const session = availableSessions.find((item) => item.id === binding.sessionId) || {
+        id: binding.sessionId,
+        title: binding.sessionTitle || binding.sessionId,
+        source: DEFAULT_SETTINGS.sessionSource,
+      };
+      await openHermesSession(session);
+      return;
+    }
+    // Mismatched profile/gateway: forget the binding so we don't resume the
+    // wrong profile's chat. The stored messages for this scope stay until the
+    // new session overwrites them.
+    const key = sessionBindingKeyForScope(contextScope, previousConversationScope);
+    await chrome.storage.local.remove([key]);
   }
   await createHermesBrowserSession({ title: makePinnedTabSessionTitle(currentContext.activeTab || previousConversationScope), focus });
 }
@@ -3123,7 +3148,7 @@ function renderProfiles() {
   for (const profile of availableProfiles) {
     const option = document.createElement('option');
     option.value = profile.name;
-    option.textContent = `${profile.name}${profile.active ? ' · active' : ''}${profile.model ? ` · ${profile.model}` : ''}`;
+    option.textContent = `${profile.name}${profile.active ? '  active' : ''}${profile.model ? `  ${profile.model}` : ''}`;
     option.selected = profile.name === selected;
     els.profileSelect.appendChild(option);
   }
@@ -3132,14 +3157,79 @@ function renderProfiles() {
   if (availableProfiles.length) {
     const active = availableProfiles.find((profile) => profile.name === selected) || availableProfiles.find((profile) => profile.active);
     els.profileStatus.textContent = active
-      ? `Using ${active.name}${active.model ? ` · ${active.model}` : ''}${active.skillCount ? ` · ${active.skillCount} skills` : ''}`
+      ? `Using ${active.name}${active.model ? `  ${active.model}` : ''}${active.skillCount ? `  ${active.skillCount} skills` : ''}`
       : `${availableProfiles.length} profiles available`;
+  } else if (isRemoteWsMode()) {
+    els.profileStatus.textContent = 'Profile API unavailable from the extension origin. Open the Hermes dashboard and sign in to select a profile.';
   } else {
     els.profileStatus.textContent = 'Profile API unavailable. Browser will use the currently running Hermes gateway profile.';
   }
 }
 
+// The profile we send to the dashboard. Empty string is a valid signal
+// (create under the running default profile), so we only fall back to the
+// dashboard-detected active profile when nothing is explicitly chosen.
+function safeActiveProfile() {
+  if (settings.activeProfile && availableProfiles.some((profile) => profile.name === settings.activeProfile)) {
+    return settings.activeProfile;
+  }
+  const detected = availableProfiles.find((profile) => profile.active)?.name || '';
+  return detected;
+}
+
+function profileDiscoveryHelp(reason = '', origin = '') {
+  switch (reason) {
+    case 'no_dashboard_tab':
+      return `Open ${origin || 'your Hermes dashboard'} in a tab and sign in, then refresh profiles.`;
+    case 'not_signed_in':
+      return 'Your Hermes dashboard tab is not signed in. Sign in there, then refresh profiles.';
+    case 'no_dashboard_session_token':
+      return 'The dashboard tab did not expose a session token; reload the dashboard and sign in.';
+    case 'bad_base_url':
+      return 'The remote gateway URL is not a valid https URL.';
+    case 'scripting_unavailable':
+      return 'This extension context cannot read the dashboard.';
+    default:
+      return `Could not discover Hermes profiles (${reason || 'unknown'}).`;
+  }
+}
+
 async function loadProfiles({ quiet = false } = {}) {
+  // Remote dashboard mode has no apiKey and its REST surface is CORS-blocked
+  // from the extension origin. Discover profiles first-party inside the
+  // signed-in dashboard tab (same trust model as ws-ticket minting).
+  if (isRemoteWsMode()) {
+    if (!settings.gatewayUrl) {
+      availableProfiles = [];
+      renderProfiles();
+      return;
+    }
+    try {
+      const result = await discoverProfilesViaTab({
+        tabsApi: chrome.tabs,
+        scriptingApi: chrome.scripting,
+        baseUrl: normalizeGatewayUrl(settings.gatewayUrl),
+      });
+      if (!result.ok) {
+        availableProfiles = [];
+        renderProfiles();
+        if (!quiet) {
+          setStatus('warn', 'Profile discovery unavailable', profileDiscoveryHelp(result.reason, normalizeGatewayUrl(settings.gatewayUrl)));
+        }
+        return;
+      }
+      availableProfiles = normalizeHermesProfiles({ profiles: result.profiles }, settings.activeProfile);
+      renderProfiles();
+      if (!quiet) {
+        setStatus('ok', 'Hermes profiles synced', `${availableProfiles.length} profile${availableProfiles.length === 1 ? '' : 's'} available`);
+      }
+    } catch (error) {
+      availableProfiles = [];
+      renderProfiles();
+      if (!quiet) setStatus('warn', 'Profile sync failed', error?.message || String(error));
+    }
+    return;
+  }
   if (!settings.apiKey || gatewayCapabilities.profiles === false) {
     availableProfiles = [];
     renderProfiles();
@@ -3166,7 +3256,17 @@ async function applySelectedProfile(profileName = '') {
   settings = { ...settings, activeProfile: profileName };
   await chrome.storage.local.set({ hermesBrowserSettings: settings });
   renderProfiles();
-  if (!profileName || !settings.apiKey) return;
+  if (!profileName) return;
+  if (isRemoteWsMode()) {
+    // Remote dashboard mode only reads profiles (discovery runs first-party in
+    // the signed-in dashboard tab); it does not POST a switch. The profile is
+    // attached to session.create, so reloading models is enough to reflect the
+    // new selection, and the next session will target it.
+    setStatus('ok', 'Hermes profile selected', `${profileName}. New sessions will use this profile.`);
+    await loadModels({ quiet: true });
+    return;
+  }
+  if (!settings.apiKey) return;
   try {
     const response = await apiFetch('/v1/profiles/active', {
       method: 'POST',
@@ -3548,6 +3648,7 @@ async function createHermesBrowserSession({ title = makeBrowserSessionTitle(), f
       title,
       reasoning_effort: normalizeReasoningEffort(settings.reasoningEffort),
       fast: normalizeFastMode(settings.fastMode),
+      profile: safeActiveProfile(),
     });
     const id = result?.session_id;
     if (!id) throw new Error('Dashboard did not return a session id.');
@@ -4664,6 +4765,7 @@ async function ensureRemoteWsSession(connection) {
     title: settings.sessionTitle,
     reasoning_effort: normalizeReasoningEffort(settings.reasoningEffort),
     fast: normalizeFastMode(settings.fastMode),
+    profile: safeActiveProfile(),
   });
   connection.wsSessionId = result?.session_id || '';
   if (!connection.wsSessionId) throw new Error('Dashboard did not return a session id.');
@@ -5126,10 +5228,12 @@ async function testConnection() {
       try {
         const models = await connection.client.request(WS_METHODS.modelOptions);
         await loadModels({ quiet: true, payload: models });
-        modelNote = availableModels.length ? ` · ${availableModels.length} models` : '';
+        modelNote = availableModels.length ? `  ${availableModels.length} models` : '';
       } catch {
         // model.options shape varies across gateways; the socket is already proven.
       }
+      // First-party profile discovery runs inside the signed-in dashboard tab.
+      await loadProfiles({ quiet: true });
       updateConnectionPrompt();
       markGatewayReachable(`${normalizeGatewayUrl(settings.gatewayUrl)}${modelNote}`);
       lastRemoteDiagnostic = null;

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -82,6 +82,8 @@ import {
   sanitizeToolPreview,
   normalizeToolActivity,
   TEXT_SIZE_OPTIONS,
+  agentDiscoveryAppliesToMode,
+  agentDiscoveryModeNote,
 } from '../extension/lib/common.mjs';
 import {
   extractYouTubeVideoId,
@@ -2107,4 +2109,29 @@ test('Nous dark theme uses Desktop-style dark blue surfaces instead of light box
   assert.match(block, /--hermes-paper:\s*#0a3572\b/i, 'dark Nous cards should be deep Hermes blue');
   assert.match(block, /--hermes-input-bg:\s*#062a60\b/i, 'dark Nous text fields should be darker blue than cards');
   assert.match(css, /textarea, input, select \{[\s\S]*?background:\s*var\(--hermes-input-bg, var\(--hermes-paper\)\)/, 'form controls should use the input surface token');
+});
+
+test('agentDiscoveryAppliesToMode is false only in remote-dashboard mode', () => {
+  assert.equal(agentDiscoveryAppliesToMode('remote-dashboard'), false);
+  assert.equal(agentDiscoveryAppliesToMode('local-api'), true);
+  assert.equal(agentDiscoveryAppliesToMode('remote-api'), true);
+  assert.equal(agentDiscoveryAppliesToMode(undefined), true);
+  assert.equal(agentDiscoveryAppliesToMode('garbage'), true);
+});
+
+test('agentDiscoveryModeNote explains skip in remote-dashboard mode', () => {
+  const remoteNote = agentDiscoveryModeNote('remote-dashboard');
+  assert.match(remoteNote, /WebSocket/i);
+  assert.match(remoteNote, /8642-8646/i);
+  assert.match(remoteNote, /Dashboard Attach/i);
+  const localNote = agentDiscoveryModeNote('local-api');
+  assert.match(localNote, /sidecar gateways/i);
+  assert.doesNotMatch(localNote, /WebSocket/i);
+});
+
+test('Connected agent section copy clarifies the scan is remote-dashboard-inapplicable', () => {
+  const html = readFileSync(new URL('../extension/sidepanel.html', import.meta.url), 'utf8');
+  assert.match(html, /id="agentList"/);
+  assert.match(html, /Scans a trusted Hermes API host for running sidecar gateways on/i);
+  assert.match(html, /Remote[\s\S]*?dashboard mode Dashboard Attach connects over the dashboard[\s\S]*?WebSocket/i);
 });

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -63,6 +63,9 @@ import {
   shouldAutoOpenSessionGroup,
   shouldAutoFlushQueuedTurn,
   shouldCreateFreshSessionOnOpen,
+  sessionBindingIdentity,
+  isSessionBindingValid,
+  withSessionBindingIdentity,
   summarizeTabs,
   compareVersionStrings,
   autoSessionTitleFromText,
@@ -762,7 +765,9 @@ test('connect and startup sync Hermes models, sessions, skills, and profiles fro
     'connected API /api/model/options must be tried before dashboard scraping',
   );
   assert.match(source, /discoverModelsFromDashboard\(\{/);
-  assert.match(source, /profile: settings\.activeProfile/);
+  assert.match(source, /profile: safeActiveProfile\(\)/);
+  assert.match(source, /safeActiveProfile\(\)/);
+  assert.match(source, /discoverProfilesViaTab\(\{/);
   assert.match(source, /dashboardModelDiscoveryBaseUrl\(\{/);
   assert.doesNotMatch(source, /loadModels\(\{ quiet: true, payload: modelsPayload \}\)/);
   assert.match(source, /shouldTrySessionModelFallback\(\{\s*registryModels,\s*registrySource,\s*defaultModelId: DEFAULT_SETTINGS\.model,\s*\}\)/s);
@@ -770,6 +775,18 @@ test('connect and startup sync Hermes models, sessions, skills, and profiles fro
   assert.match(source, /apiFetch\('\/v1\/profiles'/);
   assert.match(source, /apiFetch\(`\/api\/sessions\?limit=\$\{limit\}&offset=\$\{offset\}&include_children=true&order=recent`/);
   assert.match(source, /els\.refreshModelsButton\.addEventListener\('click', refreshModelsFromMenu\)/);
+});
+
+test('session resume is bound to gateway + profile and cannot cross profile boundaries', () => {
+  const source = readFileSync(new URL('../extension/sidepanel.js', import.meta.url), 'utf8');
+  // Remote session.create carries the selected profile.
+  assert.match(source, /profile: safeActiveProfile\(\)/);
+  // Stored bindings are written with a gateway + profile identity.
+  assert.match(source, /withSessionBindingIdentity\(/);
+  // Resume validates the binding against the current gateway + profile before reopening.
+  assert.match(source, /isSessionBindingValid\(binding, currentIdentity\)/);
+  // A mismatched binding is invalidated (removed) rather than silently resumed.
+  assert.match(source, /chrome\.storage\.local\.remove\(\[key\]\)/);
 });
 
 test('sidepanel steers dashboard runs through session.steer instead of slash-command prompt injection', () => {
@@ -1143,6 +1160,46 @@ test('normalizeHermesProfiles marks active profile and keeps useful metadata', (
   assert.equal(profiles[0].active, false);
   assert.equal(profiles[1].active, true);
   assert.equal(profiles[1].model, 'claude-sonnet-4.6');
+});
+
+test('session binding identity gates resume across gateway + profile boundaries', () => {
+  const sebastian = sessionBindingIdentity({ gatewayUrl: 'https://dash.example/', gatewayMode: 'remote-dashboard', profile: 'sebastian' });
+  const bound = withSessionBindingIdentity({ sessionId: 's1' }, sebastian);
+  assert.deepEqual(bound.identity, sebastian);
+
+  // Same gateway + profile: resume is allowed.
+  assert.equal(
+    isSessionBindingValid(bound, sessionBindingIdentity({ gatewayUrl: 'https://dash.example', gatewayMode: 'remote-dashboard', profile: 'sebastian' })),
+    true,
+  );
+
+  // Trailing slash / mode normalization must not invalidate an otherwise-equal identity.
+  assert.equal(
+    isSessionBindingValid(bound, sessionBindingIdentity({ gatewayUrl: 'https://dash.example/', gatewayMode: 'remote-dashboard', profile: 'sebastian' })),
+    true,
+  );
+
+  // Different profile: never silently resume the wrong profile's chat.
+  assert.equal(
+    isSessionBindingValid(bound, sessionBindingIdentity({ gatewayUrl: 'https://dash.example', gatewayMode: 'remote-dashboard', profile: 'default' })),
+    false,
+  );
+
+  // Deselected profile (empty) vs a selected one is still a boundary change.
+  assert.equal(
+    isSessionBindingValid(bound, sessionBindingIdentity({ gatewayUrl: 'https://dash.example', gatewayMode: 'remote-dashboard', profile: '' })),
+    false,
+  );
+
+  // Different gateway is also a boundary change.
+  assert.equal(
+    isSessionBindingValid(bound, sessionBindingIdentity({ gatewayUrl: 'https://other.example', gatewayMode: 'remote-dashboard', profile: 'sebastian' })),
+    false,
+  );
+
+  // Missing/empty binding is never valid.
+  assert.equal(isSessionBindingValid(null, sebastian), false);
+  assert.equal(isSessionBindingValid({}, sebastian), false);
 });
 
 test('version helpers compare extension update versions safely', () => {

--- a/tests/dashboard-bridge.test.mjs
+++ b/tests/dashboard-bridge.test.mjs
@@ -8,6 +8,10 @@ import {
   findDashboardTab,
   mintWsTicket,
   ticketFailureHelp,
+  dashboardProfilesUrl,
+  discoverProfilesInPage,
+  discoverProfilesViaTab,
+  discoverProfilesFromDashboard,
 } from '../extension/lib/dashboard-bridge.mjs';
 
 test('originOf and wsTicketUrl normalize the dashboard base', () => {
@@ -92,4 +96,111 @@ test('mintWsTicket injects the mint into the dashboard tab with the ticket URL',
 test('ticketFailureHelp gives actionable copy per reason', () => {
   assert.match(ticketFailureHelp('no_dashboard_tab', 'https://host.ts.net'), /Open https:\/\/host\.ts\.net.*sign in/);
   assert.match(ticketFailureHelp('not_signed_in'), /not signed in/i);
+});
+
+test('dashboardProfilesUrl builds a first-party /api/profiles URL', () => {
+  assert.equal(dashboardProfilesUrl('https://host.ts.net/'), 'https://host.ts.net/api/profiles');
+  assert.equal(dashboardProfilesUrl('https://host.ts.net/hermes'), 'https://host.ts.net/hermes/api/profiles');
+  // Pasted address-bar URL with query/hash must not corrupt the path.
+  assert.equal(dashboardProfilesUrl('https://host.ts.net/hermes?x=1#y'), 'https://host.ts.net/hermes/api/profiles');
+  assert.equal(dashboardProfilesUrl('https://host.ts.net/', 'sebastian'), 'https://host.ts.net/api/profiles?profile=sebastian');
+});
+
+test('discoverProfilesInPage bootstraps the session token and reads the roster', async () => {
+  const calls = [];
+  const fakeFetch = async (url, options = {}) => {
+    calls.push({ url: String(url), token: options.headers?.['X-Hermes-Session-Token'] || '' });
+    if (String(url).endsWith('/api/profiles')) {
+      return { ok: true, status: 200, json: async () => ({ profiles: [{ name: 'default' }, { name: 'sebastian', model: 'gpt-5' }] }) };
+    }
+    return { ok: true, status: 200, text: async () => '<script>window.__HERMES_SESSION_TOKEN__="tok123";</script>' };
+  };
+  const original = globalThis.fetch;
+  globalThis.fetch = fakeFetch;
+  try {
+    const result = await discoverProfilesInPage('https://host.ts.net/');
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.profiles.map((p) => p.name), ['default', 'sebastian']);
+    assert.equal(calls[1].token, 'tok123');
+    assert.equal(calls[1].url, 'https://host.ts.net/api/profiles');
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('discoverProfilesInPage reports not_signed_in when the dashboard rejects it', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    if (String(url).endsWith('/api/profiles')) return { ok: false, status: 401, json: async () => ({}) };
+    return { ok: true, status: 200, text: async () => '<script>window.__HERMES_SESSION_TOKEN__="tok";</script>' };
+  };
+  try {
+    const result = await discoverProfilesInPage('https://host.ts.net/');
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'not_signed_in');
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('discoverProfilesInPage reports missing token when the dashboard boot does not expose one', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: true, status: 200, text: async () => '<html>no token here</html>' });
+  try {
+    const result = await discoverProfilesInPage('https://host.ts.net/');
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'no_dashboard_session_token');
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('discoverProfilesViaTab runs first-party in a signed-in dashboard tab', async () => {
+  let injected = null;
+  const result = await discoverProfilesViaTab({
+    tabsApi: { query: async () => [{ id: 9, url: 'https://host.ts.net/x', discarded: false }] },
+    scriptingApi: {
+      executeScript: async (opts) => {
+        injected = opts;
+        return [{ result: { ok: true, profiles: [{ name: 'sebastian' }] } }];
+      },
+    },
+    baseUrl: 'https://host.ts.net',
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.profiles.map((p) => p.name), ['sebastian']);
+  assert.equal(injected.target.tabId, 9);
+  assert.deepEqual(injected.args, ['https://host.ts.net', '']);
+});
+
+test('discoverProfilesViaTab returns no_dashboard_tab when no tab is open', async () => {
+  const result = await discoverProfilesViaTab({
+    tabsApi: { query: async () => [] },
+    scriptingApi: { executeScript: async () => [{ result: { ok: true } }] },
+    baseUrl: 'https://host.ts.net',
+  });
+  assert.deepEqual(result, { ok: false, reason: 'no_dashboard_tab', origin: 'https://host.ts.net' });
+});
+
+test('discoverProfilesFromDashboard extracts the token and reads the roster via fetchFn', async () => {
+  const calls = [];
+  const fetchFn = async (url, options = {}) => {
+    calls.push({ url: String(url), token: options.headers?.['X-Hermes-Session-Token'] || '' });
+    if (String(url).endsWith('/api/profiles')) {
+      return { ok: true, status: 200, text: async () => JSON.stringify({ profiles: [{ name: 'sebastian', model: 'gpt-5' }] }) };
+    }
+    return { ok: true, status: 200, text: async () => '<script>window.__HERMES_SESSION_TOKEN__="abc";</script>' };
+  };
+  const result = await discoverProfilesFromDashboard({ baseUrl: 'https://host.ts.net/', fetchFn });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.profiles.map((p) => p.name), ['sebastian']);
+  assert.equal(calls[1].token, 'abc');
+  assert.equal(calls[1].url, 'https://host.ts.net/api/profiles');
+});
+
+test('discoverProfilesFromDashboard reports a clear error on a bad base url', async () => {
+  const result = await discoverProfilesFromDashboard({ baseUrl: '', fetchFn: () => {} });
+  assert.equal(result.ok, false);
+  assert.equal(result.error, 'no-dashboard-url');
+  assert.deepEqual(result.profiles, []);
 });


### PR DESCRIPTION
## Summary
Fixes dashboard Attach routing chats to the **default** Hermes profile instead of the requested one in remote-dashboard mode.

- **First-party profile discovery.** `loadProfiles()` now discovers profiles inside the signed-in dashboard tab via `chrome.scripting` (same trust model as ws-ticket minting) when `apiKey` is blank  no cross-origin cookie request, no REST CORS dependency. Falls back to `/v1/profiles` for local/remote-api modes.
- **Profile propagation.** `session.create` over the dashboard WebSocket now includes `profile: safeActiveProfile()`, so Browser chats target Sebastian (or the selected profile) instead of the unified default.
- **Profile-bound resume.** Stored session bindings are tagged with a `gateway + profile` identity (`sessionBindingIdentity`/`withSessionBindingIdentity`). `ensureSessionForActiveScope` refuses to resume a binding whose profile (or gateway) changed and invalidates it instead of silently crossing profile boundaries  protecting Chat-only history.
- **Trust preserved.** Discovery runs only in the trusted, signed-in dashboard tab; ticket + profile reads stay first-party. Chat-only scope and ticket security are unchanged.

## Acceptance criteria coverage
1.  Remote-dashboard discovery via trusted signed-in tab (no API key / no cross-origin cookie).
2.  Active profile selector populated and selection preserved.
3.  `profile: settings.activeProfile` (via `safeActiveProfile()`) sent in `session.create`; safe fallback to detected-active profile.
4.  Resume cannot cross profile boundaries  binding invalidated on profile change.
5.  Dashboard Attach stays Chat-only; trust/ticket security preserved.
6.  Unit/regression tests added (discovery, propagation, profile-bound resume).
7.  `npm test` (193 pass), lint (0 errors), build/package pass.

## Test plan
- `npm test`  new `dashboard-bridge.test.mjs` (discovery in-page / via tab / fetchFn) + `common.test.mjs` (binding identity gating, source assertions for `profile: safeActiveProfile()` and resume validation).
- Manual: remote-dashboard mode  open signed-in dashboard tab, connect, choose Sebastian in the profile picker, confirm new sessions target it.

## Note
Branch is based on current `origin/main`; unrelated local tree changes were not bundled.