### PR TITLE
fix(models): show hermes-agent and protect direct provider rows in the picker

### DIFF
--- a/extension/lib/model-discovery.mjs
+++ b/extension/lib/model-discovery.mjs
@@ -155,11 +155,33 @@ export function modelsFromModelOptionsPayload(payload = {}) {
         fast: typeof modelCaps.fast === 'boolean' ? modelCaps.fast : undefined,
         reasoning: typeof modelCaps.reasoning === 'boolean' ? modelCaps.reasoning : undefined,
         authenticated: provider?.authenticated !== false,
+        current: provider?.is_current === true || provider?.isCurrent === true,
         available: !unavailable.has(modelId),
         source: 'registry',
         runtimeSelectable: true,
       });
     }
+  }
+  // The gateway's synthetic meta-model (`hermes-agent`) is the default model
+  // every Hermes gateway exposes via /v1/models, but it is not listed among
+  // the configured providers of /api/model/options. It must always appear in
+  // the picker so local-gateway users are never locked out of the gateway's
+  // primary model (issue #61).
+  if (providers.length) {
+    models.unshift({
+      id: 'hermes-agent',
+      rawModelId: 'hermes-agent',
+      label: 'Hermes Agent (gateway default)',
+      provider: 'hermes',
+      providerLabel: 'Hermes Agent',
+      description: 'Default Hermes Agent meta-model exposed by the gateway',
+      contextTokens: 0,
+      authenticated: true,
+      current: true,
+      available: true,
+      source: 'registry',
+      runtimeSelectable: true,
+    });
   }
   return models;
 }
@@ -212,7 +234,7 @@ async function fetchWithTimeout(fetchFn, url, options = {}, timeoutMs = 5000) {
   }
 }
 
-function canonicalProviderModels(payload = {}, registryModels = []) {
+function canonicalProviderModels(payload = {}, registryModels = [], enrichProviders = null) {
   const providers = payload?.providers && typeof payload.providers === 'object' ? payload.providers : {};
   const templates = new Map();
   for (const model of Array.isArray(registryModels) ? registryModels : []) {
@@ -223,6 +245,13 @@ function canonicalProviderModels(payload = {}, registryModels = []) {
 
   const extras = [];
   for (const [provider, template] of templates) {
+    // Only catalog-backed providers (Nous Portal and OpenRouter) may be
+    // enriched from the canonical catalog. Direct provider rows that the
+    // gateway advertises as authenticated (DeepSeek with a local API key,
+    // OpenAI, Anthropic, ...) are authoritative: their raw model ids are
+    // already in gateway format, and injecting catalog rows would shadow or
+    // confuse the request with ids the gateway does not recognize (issue #61).
+    if (enrichProviders && !enrichProviders.has(provider)) continue;
     const entries = Array.isArray(providers?.[provider]?.models) ? providers[provider].models : [];
     for (const entry of entries) {
       const rawModelId = String(typeof entry === 'string' ? entry : entry?.id || entry?.model || entry?.name || '').trim();
@@ -285,6 +314,14 @@ export async function discoverCanonicalProviderCatalog({
   if (!hasCanonicalProvider) return { ok: true, models: currentModels, error: '', source: 'not-applicable' };
   if (typeof fetchFn !== 'function') return { ok: false, models: currentModels, error: 'no-fetch', source: 'registry' };
 
+  // Catalog-backed providers only: Nous Portal aliases plus OpenRouter.
+  // Direct provider rows advertised by the gateway are authoritative and are
+  // never overlaid with canonical catalog rows (issue #61).
+  const enrichProviders = new Set(nousProviders);
+  if (currentModels.some((model) => String(model?.provider || '').trim().toLowerCase() === 'openrouter')) {
+    enrichProviders.add('openrouter');
+  }
+
   const errors = [];
   let models = currentModels;
   let liveNousLoaded = false;
@@ -302,7 +339,7 @@ export async function discoverCanonicalProviderCatalog({
       const payload = await response.json();
       if (!Array.isArray(payload?.data)) throw new Error('invalid-live-nous-catalog');
       const providers = Object.fromEntries(nousProviders.map((provider) => [provider, { models: payload.data }]));
-      models = canonicalProviderModels({ providers }, models);
+      models = canonicalProviderModels({ providers }, models, enrichProviders);
       liveNousLoaded = true;
     } catch (error) {
       errors.push(error?.name === 'AbortError' ? 'nous-live-timeout' : (error?.message || 'nous-live-error'));
@@ -318,7 +355,7 @@ export async function discoverCanonicalProviderCatalog({
     }, timeoutMs);
     if (!response.ok) throw new Error(`status-${response.status}`);
     const payload = catalogWithNousAliases(await response.json(), nousProviders);
-    models = canonicalProviderModels(payload, models);
+    models = canonicalProviderModels(payload, models, enrichProviders);
     staticCatalogLoaded = true;
   } catch (error) {
     errors.push(error?.name === 'AbortError' ? 'canonical-timeout' : (error?.message || 'canonical-error'));

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -2928,6 +2928,7 @@ test('discoverModelsFromRegistry flattens /api/model/options provider inventory'
   assert.equal(result.error, '');
   assert.deepEqual(calls, [['/api/model/options?refresh=true', 'GET']]);
   assert.deepEqual(result.models.map((model) => model.id), [
+    'hermes-agent',
     'openai-codex::gpt-5.5',
     'openai-codex::gpt-5.4',
     'openai-codex::gpt-5.6-sol',
@@ -2936,6 +2937,7 @@ test('discoverModelsFromRegistry flattens /api/model/options provider inventory'
     'minimax::MiniMax-M3',
   ]);
   assert.deepEqual(result.models.map((model) => model.rawModelId), [
+    'hermes-agent',
     'gpt-5.5',
     'gpt-5.4',
     'gpt-5.6-sol',
@@ -2943,11 +2945,11 @@ test('discoverModelsFromRegistry flattens /api/model/options provider inventory'
     'gpt-5.6-luna',
     'MiniMax-M3',
   ]);
-  assert.equal(result.models[0].provider, 'openai-codex');
-  assert.equal(result.models[0].providerLabel, 'OpenAI Codex');
-  assert.equal(result.models[0].reasoning, true);
-  assert.equal(result.models[0].fast, true);
-  assert.equal(result.models[0].runtimeSelectable, true);
+  assert.equal(result.models[1].provider, 'openai-codex');
+  assert.equal(result.models[1].providerLabel, 'OpenAI Codex');
+  assert.equal(result.models[1].reasoning, true);
+  assert.equal(result.models[1].fast, true);
+  assert.equal(result.models[1].runtimeSelectable, true);
   const normalized = normalizeHermesModels(result.models, 'openai-codex::gpt-5.6-sol');
   assert.equal(normalized.find((model) => model.rawModelId === 'gpt-5.5')?.contextTokens, 272_000);
   for (const model of normalized.filter((item) => item.rawModelId?.startsWith('gpt-5.6-'))) {
@@ -2977,11 +2979,12 @@ test('Cloud Preview flattens provider-aware model.options payloads before render
 
   const normalized = normalizeHermesModels(modelRowsFromGatewayOptions(providerPayload));
   assert.deepEqual(normalized.map((model) => model.id), [
+    'hermes-agent',
     'openai-codex::gpt-5.6-sol',
     'openai-codex::gpt-5.6-terra',
     'nous::openai/gpt-5.5',
   ]);
-  assert.deepEqual(normalized.map((model) => model.provider), ['openai-codex', 'openai-codex', 'nous']);
+  assert.deepEqual(normalized.map((model) => model.provider), ['hermes', 'openai-codex', 'openai-codex', 'nous']);
 
   const legacyRows = [{ id: 'legacy-model', provider: 'legacy' }];
   assert.deepEqual(modelRowsFromGatewayOptions(legacyRows), legacyRows);
@@ -3033,7 +3036,7 @@ test('discoverModelsFromDashboard extracts the dashboard token and fetches model
   assert.equal(result.ok, true);
   assert.deepEqual(calls.map((call) => call.url), ['http://127.0.0.1:9119', 'http://127.0.0.1:9119/api/model/options?refresh=true&profile=worker_beta']);
   assert.equal(calls[1].token, 'abc123');
-  assert.deepEqual(result.models.map((model) => model.id), ['nous::openai/gpt-5.5']);
+  assert.deepEqual(result.models.map((model) => model.id), ['hermes-agent', 'nous::openai/gpt-5.5']);
 });
 
 test('discoverModelsFromRegistry picks up context_length from capabilities when model entries are bare strings', async () => {
@@ -3058,11 +3061,12 @@ test('discoverModelsFromRegistry picks up context_length from capabilities when 
 
   const result = await discoverModelsFromRegistry({ apiFetch, readJsonResponse });
   assert.equal(result.ok, true);
-  assert.equal(result.models.length, 2);
-  assert.equal(result.models[0].contextTokens, 1048576);
-  assert.equal(result.models[1].contextTokens, 200000);
-  assert.equal(result.models[0].reasoning, true);
-  assert.equal(result.models[0].fast, false);
+  assert.equal(result.models.length, 3); // hermes-agent + 2 provider models
+  assert.equal(result.models[0].id, 'hermes-agent');
+  assert.equal(result.models[1].contextTokens, 1048576);
+  assert.equal(result.models[2].contextTokens, 200000);
+  assert.equal(result.models[1].reasoning, true);
+  assert.equal(result.models[1].fast, false);
 });
 
 test('discoverModelsFromRegistry preserves common model context metadata aliases', async () => {
@@ -3093,6 +3097,7 @@ test('discoverModelsFromRegistry preserves common model context metadata aliases
   assert.deepEqual(
     result.models.map((model) => [model.rawModelId, model.contextTokens]),
     [
+      ['hermes-agent', 0],
       ['provider/context-window', 321000],
       ['provider/context-tokens', 654000],
       ['provider/max-context', 987000],

--- a/tests/model-discovery.test.mjs
+++ b/tests/model-discovery.test.mjs
@@ -5,6 +5,8 @@ import {
   modelCatalogCacheKey,
   normalizeCachedModelCatalog,
   selectModelCatalogFallback,
+  modelsFromModelOptionsPayload,
+  discoverCanonicalProviderCatalog,
 } from '../extension/lib/model-discovery.mjs';
 
 test('model catalog fallback prefers cached canonical providers over session history', () => {
@@ -79,4 +81,83 @@ test('model catalog cache keys isolate gateway and profile', () => {
     modelCatalogCacheKey({ gatewayMode: 'remote-dashboard', gatewayUrl: 'https://example.test', profile: 'default' }),
     modelCatalogCacheKey({ gatewayMode: 'remote-dashboard', gatewayUrl: 'https://example.test', profile: 'work' }),
   );
+});
+
+test('gateway model options always include the synthetic hermes-agent meta-model', () => {
+    const models = modelsFromModelOptionsPayload({
+      providers: [
+        { slug: 'deepseek', name: 'DeepSeek', authenticated: true, is_current: true, models: ['deepseek-v4-pro'] },
+        { slug: 'nous', name: 'Nous Portal', authenticated: true, models: ['openai/gpt-5.6-luna'] },
+      ],
+    });
+    // hermes-agent is the gateway's primary model even though /api/model/options
+    // never lists it among configured providers (issue #61).
+    assert.equal(models[0].id, 'hermes-agent');
+    assert.equal(models[0].rawModelId, 'hermes-agent');
+    assert.equal(models[0].provider, 'hermes');
+    assert.equal(models[0].providerLabel, 'Hermes Agent');
+    assert.equal(models[0].runtimeSelectable, true);
+    assert.equal(models[0].authenticated, true);
+    // The configured providers keep their gateway-format raw ids untouched.
+    assert.ok(models.some((model) => model.id === 'deepseek::deepseek-v4-pro' && model.rawModelId === 'deepseek-v4-pro'));
+    assert.ok(models.some((model) => model.id === 'nous::openai/gpt-5.6-luna'));
+  });
+
+test('gateway model options mark the current provider', () => {
+  const models = modelsFromModelOptionsPayload({
+    providers: [
+      { slug: 'deepseek', name: 'DeepSeek', authenticated: true, is_current: true, models: ['deepseek-v4-pro'] },
+      { slug: 'nous', name: 'Nous Portal', authenticated: true, is_current: false, models: ['openai/gpt-5.6-luna'] },
+    ],
+  });
+  assert.equal(models[0].current, true); // hermes-agent is always current
+  const deepseek = models.find((model) => model.provider === 'deepseek');
+  const nous = models.find((model) => model.provider === 'nous');
+  assert.equal(deepseek.current, true);
+  assert.equal(nous.current, false);
+});
+
+test('canonical catalog does not overlay authenticated direct providers', async () => {
+  const result = await discoverCanonicalProviderCatalog({
+    registryModels: [
+      {
+        id: 'nous::openai/gpt-5.6-luna',
+        rawModelId: 'openai/gpt-5.6-luna',
+        provider: 'nous',
+        providerLabel: 'Nous Portal',
+        authenticated: true,
+        runtimeSelectable: true,
+      },
+      {
+        id: 'deepseek::deepseek-v4-pro',
+        rawModelId: 'deepseek-v4-pro',
+        provider: 'deepseek',
+        providerLabel: 'DeepSeek',
+        authenticated: true,
+        current: true,
+        runtimeSelectable: true,
+      },
+    ],
+    fetchFn: async (url) => ({
+      ok: true,
+      status: 200,
+      json: async () => String(url).includes('inference-api.nousresearch.com')
+        ? { data: [{ id: 'poolside/laguna-s-2.1', name: 'Poolside: Laguna S 2.1' }] }
+        : {
+            providers: {
+              nous: { models: [{ id: 'moonshotai/kimi-k3' }] },
+              deepseek: { models: [{ id: 'deepseek-v4-pro' }, { id: 'deepseek-chat-fake' }] },
+            },
+          },
+    }),
+  });
+  const ids = result.models.map((model) => model.id);
+  // Nous Portal still receives canonical enrichment…
+  assert.ok(ids.includes('nous::poolside/laguna-s-2.1'));
+  assert.ok(ids.includes('nous::moonshotai/kimi-k3'));
+  // …but DeepSeek keeps exactly its gateway-advertised row: the catalog must
+  // never invent extra rows for authenticated direct providers (issue #61).
+  assert.ok(ids.includes('deepseek::deepseek-v4-pro'));
+  assert.ok(!ids.includes('deepseek::deepseek-chat-fake'));
+  assert.equal(result.models.filter((model) => model.provider === 'deepseek').length, 1);
 });


### PR DESCRIPTION
## The Bug

Two related model-picker failures for local-gateway users (reported in #61):

1. **`hermes-agent` never appears in the picker.** It is the gateway's primary meta-model and `/v1/models` advertises it, but `/api/model/options` only lists *configured providers*, so the synthetic alias was never rendered.
2. **Authenticated direct providers get shadowed by canonical catalog rows.** When a Nous Portal provider is present, `discoverCanonicalProviderCatalog()` overlays *every* authenticated provider — including direct providers like DeepSeek configured with a local API key — with catalog rows whose `rawModelId` uses the Nous Portal scheme. Selecting one of those rows sends an id the gateway does not recognize (`deepseek/deepseek-v4-pro` instead of `deepseek-v4-pro`) → `HTTP 404: requires available credits`, while the user's real configured model is unreachable.

## The Fix

In `extension/lib/model-discovery.mjs`:

- `modelsFromModelOptionsPayload()` now always prepends the `hermes-agent` meta-model (`provider: 'hermes'`, `runtimeSelectable: true`) whenever a real `/api/model/options` provider inventory is returned, and stamps each row with its provider's `is_current` flag.
- `discoverCanonicalProviderCatalog()` now restricts canonical catalog enrichment to catalog-backed providers only — Nous Portal aliases and OpenRouter. Authenticated direct providers keep their exact gateway-advertised rows and raw model ids; the catalog can no longer invent rows or ids the gateway will reject.

## Tests

- 3 new tests in `tests/model-discovery.test.mjs`:
  - `hermes-agent` is always present first in gateway model/options rows
  - the current provider is marked on registry rows
  - canonical enrichment never overlays an authenticated direct provider (DeepSeek keeps exactly its gateway row; a fake catalog row for the same provider is rejected) while Nous Portal still receives live/static enrichment
- Updated 5 existing assertions in `tests/common.test.mjs` that pinned the exact model list order/length to include the new `hermes-agent` row.

## Verification

- `npm test` → **703/703 pass**
- `npm run check:js` → OK (including i18n contract: 1119 messages, 21 locales)
- `npm run lint` → 0 errors (only pre-existing warnings)

Fixes #61
