### PR TITLE
fix(delegation): surface subagent batch results after the turn stream ends

### DIFF
--- a/extension/lib/async-delegation.mjs
+++ b/extension/lib/async-delegation.mjs
@@ -1,0 +1,45 @@
+// Async delegation helpers for the browser surfaces.
+//
+// The gateway dispatches delegate_task asynchronously: the turn stream ends
+// with the dispatcher's acknowledgement and the subagent batch result is
+// injected into the session later as a separate message. These helpers decide
+// when a turn triggered a delegation and when the injected batch has settled,
+// so the side panel knows to poll the session until the result lands.
+
+const ASYNC_DELEGATION_BATCH_MARKER = /\[ASYNC DELEGATION BATCH COMPLETE|deleg_[a-z0-9_-]+/i;
+const DELEGATION_TURN_MARKER = /\[ASYNC DELEGATION|deleg_[a-z0-9_-]+|dispatched.*subagent|subagent.*dispatched/i;
+
+const DEFAULT_POLL_MAX_MS = 10 * 60 * 1000;
+
+/**
+ * Whether a streamed tool event looks like a delegate/subagent dispatch.
+ * The gateway emits tool.* and hermes.tool.progress events with a raw
+ * toolName; both names are checked so remote-dashboard and local-api
+ * surfaces behave identically.
+ */
+export function isDelegationToolEvent(event = {}) {
+  const toolName = String(event?.toolName || event?.name || event?.rawName || '').toLowerCase();
+  return toolName.includes('delegate') || toolName.includes('subagent');
+}
+
+/**
+ * Whether the turn's final answer carries an async-delegation marker. This is
+ * a fallback for gateways that acknowledge a dispatch in the stream text
+ * without a separate tool event (e.g. "[ASYNC DELEGATION — deleg_abc]").
+ */
+export function turnMentionsDelegation(finalAnswer = '') {
+  return DELEGATION_TURN_MARKER.test(finalAnswer || '');
+}
+
+/**
+ * Whether an injected subagent batch has landed: either the session grew past
+ * the turn baseline (the batch result was appended) or the last assistant
+ * message carries the gateway's async-delegation completion marker. A hard
+ * time cap stops the watch from running forever if the gateway never reports.
+ */
+export function delegationBatchSettled(messages = [], baselineCount = 0, startedAt = 0, maxMs = DEFAULT_POLL_MAX_MS) {
+  if (!Array.isArray(messages) || messages.length > baselineCount) return true;
+  const last = messages.length ? messages[messages.length - 1] : null;
+  if (last?.role === 'assistant' && ASYNC_DELEGATION_BATCH_MARKER.test(String(last.content || ''))) return true;
+  return Date.now() - startedAt >= maxMs;
+}

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -154,6 +154,7 @@ import {
 } from './lib/capabilities.mjs';
 import { normalizeBrowserRuntimeEvent, reduceAssistantStreamText } from './lib/runtime-events.mjs';
 import { taskStackFromToolEvent, taskStackProgress, updateTaskStackStore } from './lib/task-stack.mjs';
+import { isDelegationToolEvent, turnMentionsDelegation, delegationBatchSettled } from './lib/async-delegation.mjs';
 import { classifyTurnRecovery, latestAssistantAfterUser, sessionContextFailureRecovery } from './lib/turn-recovery.mjs';
 import { createDiffusionCanvas, diffusionVariantForSeed } from './lib/diffusion-canvas.mjs';
 import { buildSupportDiagnostics } from './lib/support-diagnostics.mjs';
@@ -567,6 +568,7 @@ function renderTaskStack() {
 }
 
 async function captureTaskToolEvent(event) {
+  if (isDelegationToolEvent(event)) sawDelegationToolThisTurn = true;
   const tasks = taskStackFromToolEvent(event);
   if (!tasks) return false;
   const sessionId = String(settings.sessionId || '').trim();
@@ -575,6 +577,58 @@ async function captureTaskToolEvent(event) {
   renderTaskStack();
   await chrome.storage.local.set({ [TASK_STACKS_STORAGE_KEY]: taskStackStore });
   return true;
+}
+
+// --- Async delegation watch -------------------------------------------------
+// When the gateway dispatches a delegate_task, the turn stream ends with the
+// dispatcher's acknowledgement and the subagent batch result is injected into
+// the session later asynchronously. The chat is an SSE stream, so nothing
+// renders after the turn unless we poll the session until the batch lands.
+let sawDelegationToolThisTurn = false;
+let delegationWatchTimer = null;
+let delegationWatchGeneration = 0;
+const DELEGATION_POLL_INTERVAL_MS = 2_500;
+const DELEGATION_POLL_MAX_MS = 10 * 60 * 1000;
+
+function cancelDelegationWatch() {
+  delegationWatchGeneration += 1;
+  if (delegationWatchTimer) {
+    clearTimeout(delegationWatchTimer);
+    delegationWatchTimer = null;
+  }
+}
+
+function watchForDelegationResults(finalAnswer = '') {
+  if (!sawDelegationToolThisTurn && !turnMentionsDelegation(finalAnswer)) return;
+  sawDelegationToolThisTurn = false;
+  const sessionId = String(settings.sessionId || '').trim();
+  if (!sessionId) return;
+  cancelDelegationWatch();
+  const generation = ++delegationWatchGeneration;
+  const startedAt = Date.now();
+  const baselineCount = messages.length;
+  setStatus('warn', 'Delegation in progress', 'Waiting for the subagent batch to complete — results appear here automatically.');
+  const poll = async () => {
+    if (generation !== delegationWatchGeneration) return;
+    if (String(settings.sessionId || '').trim() !== sessionId) {
+      delegationWatchTimer = null;
+      return;
+    }
+    try {
+      await loadSessionMessages(sessionId);
+    } catch (error) {
+      console.warn('[Hermes Browser] Delegation result poll failed:', error);
+    }
+    if (generation !== delegationWatchGeneration) return;
+    const settled = delegationBatchSettled(messages, baselineCount, startedAt, DELEGATION_POLL_MAX_MS);
+    if (!settled && !sending) {
+      delegationWatchTimer = setTimeout(poll, DELEGATION_POLL_INTERVAL_MS);
+    } else {
+      delegationWatchTimer = null;
+      if (settled) setStatus('ok', 'Delegation complete', 'Subagent results loaded.');
+    }
+  };
+  delegationWatchTimer = setTimeout(poll, DELEGATION_POLL_INTERVAL_MS);
 }
 
 let activeSessionRuntime = {
@@ -7582,6 +7636,8 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
   }
 
   if (!guardForeignSessionSend(userText, turnAttachments)) return false;
+  cancelDelegationWatch();
+  sawDelegationToolThisTurn = false;
   const autoTitle = turnOptions.disableAutoTitle ? '' : autoTitleForCurrentTurn(userText);
   sending = true;
     if (!isRemoteWsMode()) {
@@ -7762,6 +7818,7 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
     await streamView.flush(finalAnswer);
     messages.push({ role: 'assistant', content: finalAnswer, ts: Date.now() });
     await trimAndSaveMessages();
+    watchForDelegationResults(finalAnswer);
     if (autoTitle) await maybeAutoNameCurrentSession(autoTitle);
     if (contextDelivery !== CONTEXT_DELIVERY_MODES.NONE) {
       contextDeliveryBySession.set(contextDeliverySessionKey, recordContextDelivery(

--- a/tests/async-delegation.test.mjs
+++ b/tests/async-delegation.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isDelegationToolEvent,
+  turnMentionsDelegation,
+  delegationBatchSettled,
+} from '../extension/lib/async-delegation.mjs';
+
+test('delegation tool events are detected across event name shapes', () => {
+  assert.equal(isDelegationToolEvent({ toolName: 'delegate_task' }), true);
+  assert.equal(isDelegationToolEvent({ name: 'delegate_task' }), true);
+  assert.equal(isDelegationToolEvent({ rawName: 'delegate_task' }), true);
+  assert.equal(isDelegationToolEvent({ toolName: 'tools.subagent' }), true);
+  assert.equal(isDelegationToolEvent({ toolName: 'mcp__delegate_task' }), true);
+  assert.equal(isDelegationToolEvent({ toolName: 'subagent-run' }), true);
+  assert.equal(isDelegationToolEvent({ toolName: 'todo' }), false);
+  assert.equal(isDelegationToolEvent({ toolName: 'web_search' }), false);
+  assert.equal(isDelegationToolEvent({}), false);
+  assert.equal(isDelegationToolEvent(null), false);
+});
+
+test('turn answers that mention an async delegation are recognized', () => {
+  assert.equal(turnMentionsDelegation('[ASYNC DELEGATION — deleg_abc123] Dispatched'), true);
+  assert.equal(turnMentionsDelegation('dispatched a subagent to research pricing'), true);
+  assert.equal(turnMentionsDelegation('Delegated to deleg_7f3c; waiting for results.'), true);
+  assert.equal(turnMentionsDelegation('The delegation is complete.'), false);
+  assert.equal(turnMentionsDelegation('Here is the answer to your question.'), false);
+  assert.equal(turnMentionsDelegation(''), false);
+});
+
+test('delegation batch settles when the session grows past the turn baseline', () => {
+  const baseline = 2;
+  const now = Date.now();
+  const settled = delegationBatchSettled(
+    [
+      { role: 'user', content: 'dispatch' },
+      { role: 'assistant', content: 'Dispatched' },
+      { role: 'assistant', content: 'Subagent batch result: done.' },
+    ],
+    baseline,
+    now - 1000,
+  );
+  assert.equal(settled, true);
+});
+
+test('delegation batch settles on the gateway completion marker', () => {
+  const baseline = 2;
+  const settled = delegationBatchSettled(
+    [
+      { role: 'user', content: 'dispatch' },
+      { role: 'assistant', content: '[ASYNC DELEGATION BATCH COMPLETE — deleg_abc123]' },
+    ],
+    baseline,
+    Date.now() - 1000,
+  );
+  assert.equal(settled, true);
+});
+
+test('delegation batch stays unsettled while the session is unchanged', () => {
+  const baseline = 2;
+  const settled = delegationBatchSettled(
+    [
+      { role: 'user', content: 'dispatch' },
+      { role: 'assistant', content: 'Dispatched' },
+    ],
+    baseline,
+    Date.now() - 1000,
+  );
+  assert.equal(settled, false);
+});
+
+test('delegation batch times out after the poll budget', () => {
+  const baseline = 2;
+  const settled = delegationBatchSettled(
+    [
+      { role: 'user', content: 'dispatch' },
+      { role: 'assistant', content: 'Dispatched' },
+    ],
+    baseline,
+    Date.now() - 601_000,
+  );
+  assert.equal(settled, true);
+});
+
+test('delegation batch is not settled with no messages until the timeout', () => {
+  assert.equal(delegationBatchSettled([], 0, Date.now()), false);
+  assert.equal(delegationBatchSettled([], 0, Date.now() - 601_000), true);
+});


### PR DESCRIPTION
## The Bug

Reported in #55: when the Hermes agent dispatches a `delegate_task`, the turn SSE stream ends with the dispatcher's acknowledgement, and the subagent batch result is injected into the session **later**, asynchronously. The side panel never renders it — no spinner, no result — until the user manually sends another message, which finally triggers a session reload.

## The Fix

A post-turn **delegation watch** in the side panel:

1. **Detection** — `captureTaskToolEvent` now flags any delegate/subagent tool event, and the turn's final answer is checked for an async-delegation marker (fallback for gateways that acknowledge dispatch in the stream text).
2. **Polling** — after a turn that triggered a delegation, the panel polls `loadSessionMessages()` every 2.5s (works for both REST local-api and remote-dashboard WebSocket modes) until the batch lands.
3. **Settling** — the watch stops when the session grew past the turn baseline, when the last assistant message carries the gateway's `[ASYNC DELEGATION BATCH COMPLETE — deleg_XXX]` marker, or after a hard 10-minute timeout. The injected result renders automatically via the existing session render path.
4. **Hygiene** — a new user turn or session switch cancels the watch; polling pauses while a send is in flight.

New pure module `extension/lib/async-delegation.mjs` keeps the logic unit-testable (`isDelegationToolEvent`, `turnMentionsDelegation`, `delegationBatchSettled`).

## Tests

- 7 new unit tests in `tests/async-delegation.test.mjs` covering event-name shapes, answer markers, session-growth settling, completion-marker settling, timeout behavior.

## Verification

- `node --test tests/*.test.mjs` → **709/709 pass** (the single failing test, `content-extraction-runtime`, is a pre-existing Windows CRLF artifact: `content-extractor.js` is checked out with CRLF while the generator emits LF — it fails identically on a pristine `origin/main` checkout with no changes; CI on Linux is unaffected).
- `npm run lint` → 0 errors (10 pre-existing warnings in sidepanel.js, untouched).
- `node --check` on both changed JS files passes.

Fixes #55
