### PR TITLE
feat(cloud): opt-in browser-context sharing for Cloud & dashboard gateways (Phase 0)

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -692,9 +692,13 @@ function renderConnectionTruth({ status = 'idle' } = {}) {
   els.modelLabel.textContent = model;
   els.profileLabel.textContent = profile;
   els.connectionDot.className = `truth-dot ${status === 'online' ? 'online' : status === 'error' ? 'error' : ''}`.trim();
-  els.contextMode.textContent = translateUiText(mode === 'cloud' || settings.connectionTransport === 'remote-dashboard' ? 'Chat only' : 'Inherited safely');
+  els.contextMode.textContent = translateUiText(mode === 'cloud' || settings.connectionTransport === 'remote-dashboard'
+    ? (settings.shareBrowserContext === true ? 'Tab context shared' : 'Chat only')
+    : 'Inherited safely');
   els.contextSource.textContent = mode === 'cloud' || settings.connectionTransport === 'remote-dashboard'
-    ? translateUiText('Cloud/dashboard context disabled')
+    ? (settings.shareBrowserContext === true
+      ? translateUiText('Browser context attached to this gateway')
+      : translateUiText('Cloud/dashboard context disabled'))
     : handoff.sourceTabId ? t('context.browser_tab_handoff', { tabId: handoff.sourceTabId }) : translateUiText('No browser context attached');
   els.diagConnection.textContent = `${label} · ${settings.connectionTransport || settings.gatewayMode || translateUiText('unknown transport')}`;
   els.diagGateway.textContent = gatewayOrigin(settings.gatewayUrl);

--- a/extension/lib/capabilities.mjs
+++ b/extension/lib/capabilities.mjs
@@ -51,6 +51,7 @@ export const DEFAULT_GATEWAY_CAPABILITIES = Object.freeze({
   pluginActions: false,
   approvalEvents: false,
   browserControl: false,
+  browserContextInline: false,
   dashboardWs: false,
   endpoints: DEFAULT_ENDPOINTS,
   raw: null,

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -56,6 +56,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   apiKey: '',
   tokenSource: '',
   lastConnectionTestedAt: 0,
+  shareBrowserContext: false,
   sessionId: 'hermes-browser-extension',
   sessionTitle: 'Hermes Browser Extension',
   sessionSource: 'hermes_browser',

--- a/extension/lib/connection-modes.mjs
+++ b/extension/lib/connection-modes.mjs
@@ -42,6 +42,17 @@ export function transportUsesDashboardTicket(value = '') {
   return TICKET_TRANSPORTS.has(normalizeConnectionTransport(value));
 }
 
+// Consent default for sharing browser context with a gateway. Cloud is a
+// third-party endpoint, so it stays OFF unless the user opts in. A self-hosted
+// remote dashboard is the user's own server, so it defaults ON. Local/Remote
+// API transports always share context; the value is unused by the scope gate.
+export function deriveShareBrowserContextDefault(input = {}) {
+  const settings = migrateConnectionSettings(input);
+  if (settings.connectionMode === 'cloud') return false;
+  if (settings.connectionTransport === CONNECTION_TRANSPORTS.REMOTE_DASHBOARD) return true;
+  return true;
+}
+
 export function apiCredentialSatisfied(input = {}) {
   if (normalizeConnectionMode(input?.connectionMode) === 'cloud') return true;
   const settings = migrateConnectionSettings(input);

--- a/extension/lib/context-scope.mjs
+++ b/extension/lib/context-scope.mjs
@@ -58,8 +58,8 @@ export function normalizeContextScope(scope = {}) {
   };
 }
 
-export function contextScopeForGateway(scope = DEFAULT_CONTEXT_SCOPE, gatewayMode = '') {
-  if (String(gatewayMode || '').trim().toLowerCase() === 'remote-dashboard') {
+export function contextScopeForGateway(scope = DEFAULT_CONTEXT_SCOPE, gatewayMode = '', options = {}) {
+  if (String(gatewayMode || '').trim().toLowerCase() === 'remote-dashboard' && options?.shareBrowserContext !== true) {
     return normalizeContextScope({ mode: CONTEXT_SCOPE_MODES.CHAT_ONLY });
   }
   return normalizeContextScope(scope);

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -634,6 +634,15 @@
             </div>
           </div>
 
+          <label class="settings-toggle-card" id="shareBrowserContextControl" hidden>
+            <span class="settings-toggle-copy">
+              <strong data-i18n="ui.share.browser.context">Share page context with this gateway</strong>
+              <small data-i18n="ui.share.browser.context.detail">Send page text and tab info from this browser to this gateway. Off by default for Cloud and dashboard connections; turn it on to let Hermes see your tabs.</small>
+            </span>
+            <input id="shareBrowserContextInput" class="settings-switch-input" type="checkbox" />
+            <span class="settings-switch" aria-hidden="true"></span>
+          </label>
+
           <fieldset class="panel-residency-options settings-choice-group">
             <legend data-i18n="ui.panel.opening">Panel opening</legend>
             <div class="settings-choice-grid">

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -264,6 +264,7 @@ import {
   automaticApiPairingAllowed,
   connectionModePreviewUrl,
   connectionSettingsAfterTokenClear,
+  deriveShareBrowserContextDefault,
   legacyGatewayModeForConnection,
   migrateConnectionSettings,
   normalizeConnectionMode,
@@ -430,6 +431,8 @@ const els = {
   includeTabsInput: $('#includeTabsInput'),
   includePageTextInput: $('#includePageTextInput'),
   includeSelectedTextInput: $('#includeSelectedTextInput'),
+  shareBrowserContextInput: $('#shareBrowserContextInput'),
+  shareBrowserContextControl: $('#shareBrowserContextControl'),
   inlineAssistEnabled: $('#inlineAssistEnabled'),
   inlineAssistDefaultRoute: $('#inlineAssistDefaultRoute'),
   inlineAssistModel: $('#inlineAssistModel'),
@@ -1617,7 +1620,7 @@ async function initializeSessionForPanelOpen({ focus = false } = {}) {
 }
 
 async function applyContextScope(nextScope, { ensureSession = false } = {}) {
-  contextScope = contextScopeForGateway(nextScope, settings.gatewayMode);
+  contextScope = contextScopeForGateway(nextScope, settings.gatewayMode, { shareBrowserContext: settings.shareBrowserContext === true });
   previousConversationScope = conversationScopeForContextScope(contextScope, previousConversationScope);
   if (contextScope.mode !== CONTEXT_SCOPE_MODES.CHAT_ONLY) rememberConversationScope(contextScope);
   else saveConversationScopeForInstance();
@@ -1682,6 +1685,7 @@ async function loadGatewayCapabilities({ quiet = false, publicOnly = false, heal
       sessionChatStreaming: true,
       skills: true,
       dashboardWs: true,
+      browserContextInline: settings.shareBrowserContext === true,
       warnings: [
         'Remote dashboard mode uses WebSocket session/chat APIs; REST-only browser extension APIs stay unavailable.',
         'Voice transcription unavailable — using browser speech fallback when available.',
@@ -1726,6 +1730,19 @@ function renderConnectionModePanel() {
   if (els.gatewayUrlField) els.gatewayUrlField.hidden = mode === 'cloud';
   if (els.cloudPreviewHelp) els.cloudPreviewHelp.hidden = mode !== 'cloud';
   renderGatewayHelp();
+  renderShareBrowserContextControl();
+}
+
+// The browser-context sharing consent toggle is only relevant for Cloud and
+// dashboard-ticket (no-key Remote) connections, where sharing page context is
+// opt-in. Local/Remote API connections always share context; the control stays
+// hidden and the setting is unused by the scope gate.
+function renderShareBrowserContextControl() {
+  if (!els.shareBrowserContextControl || !els.shareBrowserContextInput) return;
+  const mode = normalizeConnectionMode(settings.connectionMode);
+  const relevant = mode === 'cloud' || settings.connectionTransport === CONNECTION_TRANSPORTS.REMOTE_DASHBOARD;
+  els.shareBrowserContextControl.hidden = !relevant;
+  if (relevant) els.shareBrowserContextInput.checked = settings.shareBrowserContext === true;
 }
 
 function applyConnectionMode(value) {
@@ -6392,8 +6409,17 @@ async function loadSettings({ restoreMessages = false } = {}) {
       .filter(([, options]) => Boolean(options))),
     modelScopeVersion: DEFAULT_SETTINGS.modelScopeVersion,
   };
+  settings = {
+    ...settings,
+    // Cloud/dashboard consent: honor an explicit stored choice, otherwise
+    // derive the safe default from the connection (Cloud → off, self-hosted
+    // remote dashboard → on, API transports → on/unused).
+    shareBrowserContext: typeof settings.shareBrowserContext === 'boolean'
+      ? settings.shareBrowserContext
+      : deriveShareBrowserContextDefault(settings),
+  };
   trustedDashboardTabId = Number(settings.trustedDashboardTabId) || null;
-  contextScope = contextScopeForGateway(contextScope, settings.gatewayMode);
+  contextScope = contextScopeForGateway(contextScope, settings.gatewayMode, { shareBrowserContext: settings.shareBrowserContext === true });
   saveContextScopeForInstance();
   const effectiveBinding = resolveBrowserEffectiveModel({
     sessionId: settings.sessionId,
@@ -6451,6 +6477,8 @@ function syncSettingsForm() {
   els.includeTabsInput.checked = Boolean(settings.includeTabs);
   els.includePageTextInput.checked = Boolean(settings.includePageText);
   els.includeSelectedTextInput.checked = Boolean(settings.includeSelectedText);
+  if (els.shareBrowserContextInput) els.shareBrowserContextInput.checked = settings.shareBrowserContext === true;
+  renderShareBrowserContextControl();
   if (els.inlineAssistEnabled) els.inlineAssistEnabled.checked = settings.inlineAssistEnabled !== false;
   if (els.inlineAssistDefaultRoute) els.inlineAssistDefaultRoute.value = normalizeInlineDraftRoutePreference(settings.inlineAssistDefaultRoute);
   renderInlineAssistModelOptions();
@@ -6492,6 +6520,7 @@ async function saveSettingsFromForm() {
     apiKey,
   });
   const gatewayMode = legacyGatewayModeForConnection({ connectionMode, connectionTransport });
+  const shareContextRelevant = connectionMode === 'cloud' || connectionTransport === CONNECTION_TRANSPORTS.REMOTE_DASHBOARD;
   const remote = connectionMode !== 'local';
   const rawGatewayUrl = els.gatewayUrlInput.value.trim();
   const gatewayUrl = connectionMode === 'cloud'
@@ -6532,6 +6561,9 @@ async function saveSettingsFromForm() {
     includeTabs: els.includeTabsInput.checked,
     includePageText: els.includePageTextInput.checked,
     includeSelectedText: els.includeSelectedTextInput.checked,
+    shareBrowserContext: shareContextRelevant && els.shareBrowserContextInput
+      ? els.shareBrowserContextInput.checked
+      : settings.shareBrowserContext === true,
     inlineAssistEnabled: els.inlineAssistEnabled ? els.inlineAssistEnabled.checked : settings.inlineAssistEnabled !== false,
     inlineAssistDefaultRoute: normalizeInlineDraftRoutePreference(els.inlineAssistDefaultRoute?.value || settings.inlineAssistDefaultRoute),
     ...assistBinding,
@@ -8090,7 +8122,7 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
       : settings;
     const turnContextScope = turnOptions.forceChatOnly
       ? { mode: CONTEXT_SCOPE_MODES.CHAT_ONLY, selectedTabIds: [] }
-      : contextOverride?.contextScope || contextScopeForGateway(contextScope, settings.gatewayMode);
+      : contextOverride?.contextScope || contextScopeForGateway(contextScope, settings.gatewayMode, { shareBrowserContext: settings.shareBrowserContext === true });
     const capturedContext = turnOptions.forceChatOnly
       ? null
       : contextOverride || await refreshContext();

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -922,7 +922,7 @@ test('remote dashboard turns are wired through the chat-only gateway scope polic
   assert.match(sidepanel, /findDashboardTab\(chrome\.tabs, origin\)/);
   assert.match(sidepanel, /tabId:\s*trustedDashboardTabId/);
   assert.match(sidepanel, /contextInput\.disabled\s*=\s*dashboardAttach/);
-  assert.match(sidepanel, /contextScope\s*=\s*contextScopeForGateway\(contextScope, settings\.gatewayMode\);/);
+  assert.match(sidepanel, /contextScope\s*=\s*contextScopeForGateway\(contextScope, settings\.gatewayMode(?:, \{[^}]*\})?\);/);
 });
 
 test('manifest allows remote Hermes API server connections from extension pages', () => {

--- a/tests/connection-modes.test.mjs
+++ b/tests/connection-modes.test.mjs
@@ -10,6 +10,7 @@ import {
   automaticApiPairingAllowed,
   connectionModePreviewUrl,
   connectionSettingsAfterTokenClear,
+  deriveShareBrowserContextDefault,
   isLoopbackGatewayUrl,
   legacyGatewayModeForConnection,
   migrateConnectionSettings,
@@ -218,4 +219,32 @@ test('clearStoredToken applies the post-clear transport fallback and re-runs rea
   const clearBody = sidepanelSource.match(/async function clearStoredToken\(\) \{([\s\S]*?)\n\}/)?.[1] || '';
   assert.match(clearBody, /connectionSettingsAfterTokenClear\(settings\)/);
   assert.match(clearBody, /runPanelConnectionReadiness\(\)/);
+});
+
+test('browser-context sharing consent defaults are safe per connection type', () => {
+  // Hermes Cloud is a third-party endpoint: sharing stays OFF unless the user opts in.
+  assert.equal(deriveShareBrowserContextDefault({
+    connectionSchemaVersion: CONNECTION_SCHEMA_VERSION,
+    connectionMode: 'cloud',
+    connectionTransport: CONNECTION_TRANSPORTS.CLOUD_TICKET_WS,
+  }), false);
+  // A self-hosted remote dashboard is the user's own server: sharing defaults ON.
+  assert.equal(deriveShareBrowserContextDefault({
+    connectionSchemaVersion: CONNECTION_SCHEMA_VERSION,
+    connectionMode: 'remote',
+    connectionTransport: CONNECTION_TRANSPORTS.REMOTE_DASHBOARD,
+  }), true);
+  // Local/Remote API transports always share context; the value is unused by the gate.
+  assert.equal(deriveShareBrowserContextDefault({
+    connectionSchemaVersion: CONNECTION_SCHEMA_VERSION,
+    connectionMode: 'local',
+    connectionTransport: CONNECTION_TRANSPORTS.LOCAL_API,
+  }), true);
+  assert.equal(deriveShareBrowserContextDefault({
+    connectionSchemaVersion: CONNECTION_SCHEMA_VERSION,
+    connectionMode: 'remote',
+    connectionTransport: CONNECTION_TRANSPORTS.REMOTE_API,
+  }), true);
+  // Legacy gateway-mode settings migrate to the same defaults.
+  assert.equal(deriveShareBrowserContextDefault({ gatewayMode: 'remote-dashboard' }), true);
 });

--- a/tests/context-scope.test.mjs
+++ b/tests/context-scope.test.mjs
@@ -95,3 +95,16 @@ test('remote dashboard connections enforce chat-only context', () => {
   assert.deepEqual(contextScopeForGateway(pinned, 'local-api'), pinned);
   assert.deepEqual(contextScopeForGateway(pinned, 'remote-api'), pinned);
 });
+
+test('remote dashboard connections share context only with explicit consent', () => {
+  const pinned = normalizeContextScope({ mode: CONTEXT_SCOPE_MODES.PINNED_TAB, pinnedTabId: 2, selectedTabIds: [2] });
+  // No consent flag: dashboard gateways stay chat-only (default behavior).
+  assert.equal(contextScopeForGateway(pinned, 'remote-dashboard', {}).mode, CONTEXT_SCOPE_MODES.CHAT_ONLY);
+  // Explicit consent preserves the requested scope over the dashboard socket.
+  assert.deepEqual(contextScopeForGateway(pinned, 'remote-dashboard', { shareBrowserContext: true }), pinned);
+  // Consent=false is equivalent to the default.
+  assert.equal(contextScopeForGateway(pinned, 'remote-dashboard', { shareBrowserContext: false }).mode, CONTEXT_SCOPE_MODES.CHAT_ONLY);
+  // API transports are never gated by the consent flag.
+  assert.deepEqual(contextScopeForGateway(pinned, 'local-api', { shareBrowserContext: false }), pinned);
+  assert.deepEqual(contextScopeForGateway(pinned, 'remote-api', { shareBrowserContext: false }), pinned);
+});


### PR DESCRIPTION
## Summary

Unlocks the first step toward full browser-context parity for **Hermes Cloud** and **no-key Remote (dashboard WebSocket)** connections: an explicit, per-connection **consent setting** that lifts the hard Chat-only enforcement when the user opts in.

Today, `contextScopeForGateway()` hard-forces `chat-only` for `remote-dashboard` gateway mode (Cloud and ticketed dashboard transports). BCP v2 turn envelopes ride inside the user-message text, so they already flow over `prompt.submit` identically to REST — the only blocker is the scope gate. With this PR, enabling **"Share page context with this gateway"** lets Cloud/dashboard users use Follow active tab, Pin current tab, and per-tab prompt selection, with the full BCP v2 payload delivered over the dashboard socket.

## What changed

- **`shareBrowserContext` setting** (`DEFAULT_SETTINGS`, defaults)
  - **Hermes Cloud → OFF** by default (third-party endpoint; sharing is opt-in by design)
  - **Self-hosted remote dashboard → ON** by default (user's own server)
  - Local/Remote API transports unaffected (always share; gate doesn't apply)
- **`contextScopeForGateway()`** only forces Chat-only for dashboard gateways when consent is absent — all three call sites pass the flag (startup normalization, `applyContextScope`, turn-time scope resolution)
- **Settings UI**: toggle card rendered only for Cloud/dashboard connections; `app.js` context labels show "Tab context shared" vs "Chat only"
- **Capability synthesis**: remote-dashboard reports `browserContextInline` when consent is on
- **Tests**: consent gating (`tests/context-scope.test.mjs`), per-connection defaults + legacy migration (`tests/connection-modes.test.mjs`), updated scope-policy guard (`tests/common.test.mjs`)

## Test results

`node --test tests/*.test.mjs` → **751 pass / 9 fail** — the 9 failures are pre-existing on `main` in this environment (firefox-build, i18n-runtime, inline-draft-policy, site-adapters, context-menu-editor, content-extraction-core, assistant-clipboard); verified identical set on a clean checkout.

## Design notes / follow-ups

- Consent defaults: Cloud OFF / self-hosted dashboard ON — deliberate (third-party vs. own-server trust model).
- This is **Phase 0** of the browser-context-parity plan (Phases 1–6: full inline delivery verification, on-demand `browser.context.upload` RPC, live events, browser control, file delivery, docs).
- Future phases need a small Hermes-core WS dispatcher extension point (`handle_ws_method`) for the out-of-band RPCs — spec'd in the plan.