### PR TITLE
feat: full dashboard companion surface — context upload, events, control, file delivery (Phases 2–7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in **browser-context sharing for Hermes Cloud and no-key Remote (dashboard WebSocket) connections** (`shareBrowserContext`): Cloud defaults OFF (third-party endpoint; sharing is a per-connection consent decision), self-hosted remote dashboards default ON. When enabled, Follow active tab, Pin current tab, and per-tab prompt selection work over the dashboard socket with full BCP v2 delivery, and the companion plugin's context tools (`browser_context_status`, `browser_get_context`) activate.
+- Added the dashboard WS companion surface: `browser.context.upload` (out-of-band context push enabling hash-reference turns), `browser.events.publish` (tab/page lifecycle metadata), `file.delivery` (agent → extension downloadable file cards via `chrome.downloads`), and `browser.control` (opt-in agent-driven browser actions with per-action approval cards). All degrade to full-inline delivery on cores without the RPCs.
+- Added `allowBrowserControl` opt-in setting: lets the agent navigate/click/type/scroll/snapshot/extract in the active tab, gated by context-sharing consent, an explicit setting, and per-action approval.
+
+### Changed
+
+- `contextScopeForGateway()` only forces Chat-only for dashboard gateways when context sharing is not consented; all scope call sites (startup, `applyContextScope`, turn-time) honor the setting.
+- Remote-dashboard capability synthesis reports `browserContextInline` and `browserControl` honestly; `app.js` context labels show "Tab context shared" vs "Chat only".
+
 ## [0.2.0] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Browser-native side panel for [Hermes Agent](https://hermes-agent.nousresearch.c
 
 ## What it is
 
-Hermes Browser Extension is not a browser chatbot. It is a Chrome/Edge/Chromium side panel for the real Hermes Agent runtime. Choose a local gateway, attach to a signed-in Hermes Cloud agent tab, or connect to a self-hosted remote API/dashboard. Local and remote API connections can use the models, tools, skills, sessions, memory, and MCP servers already configured in Hermes; Cloud and dashboard-ticket connections are intentionally Chat-only.
+Hermes Browser Extension is not a browser chatbot. It is a Chrome/Edge/Chromium side panel for the real Hermes Agent runtime. Choose a local gateway, attach to a signed-in Hermes Cloud agent tab, or connect to a self-hosted remote API/dashboard. Local and remote API connections can use the models, tools, skills, sessions, memory, and MCP servers already configured in Hermes; Cloud and dashboard-ticket connections are Chat-only until you opt in to context sharing in Settings.
 
 This repo is specifically for the **Hermes Browser Extension**: the Chrome/Edge/Chromium side-panel integration for Hermes Agent.
 
@@ -39,7 +39,7 @@ Private surfaces use per-site context controls and conservative defaults. Browse
 
 Open the extension's full view for canonical Hermes sessions, model/runtime control, rich messages, generated media, and accurate session context telemetry in a browser-native workspace.
 
-Hermes Web Alpha currently uses token-backed **Local or Remote API** connections. Hermes Cloud Preview and ticketed remote-dashboard transports remain Chat-only in the side panel; live full-view dashboard handoff is not shipped yet.
+Hermes Web Alpha currently uses token-backed **Local or Remote API** connections. Hermes Cloud Preview and ticketed remote-dashboard transports are Chat-only by default with opt-in context sharing in the side panel; live full-view dashboard handoff is not shipped yet.
 
 <p align="center">
   <img src="./assets/readme/hermes-web-new-session.png" alt="Hermes Web in Nous Light mode showing a connected new-session workspace with session rail, composer, and context inspector" width="100%" />
@@ -110,10 +110,10 @@ Hermes Web Alpha currently uses token-backed **Local or Remote API** connections
 | Firefox | Preview package | `npm run build:firefox` produces `dist/firefox/` with Firefox-specific manifest adaptation. Chrome/Edge/Chromium remain the primary public support target. |
 | Safari | Not shipped | Browser-family diagnostics exist, but no Safari package is included. |
 | Local Hermes API server | Yes | Default path: `http://127.0.0.1:8642`. |
-| Hermes Cloud | Yes, Trusted Dashboard Attach | Requires an active signed-in HTTPS Hermes Cloud agent tab. Uses a single-use WebSocket ticket and enforces Chat-only context. This is not a general cookie import or background account-discovery flow. |
+| Hermes Cloud | Yes, Trusted Dashboard Attach | Requires an active signed-in HTTPS Hermes Cloud agent tab. Uses a single-use WebSocket ticket and is Chat-only until you opt in to context sharing. This is not a general cookie import or background account-discovery flow. |
 | Remote API server | Yes, explicit URL/token only | Use trusted LAN/Tailscale/VPN or HTTPS reverse proxy; do not expose Hermes naked to the internet. |
-| Self-hosted remote dashboard WebSocket | Best-effort | Select Remote gateway with an HTTPS dashboard URL and no API key. Chat/session/model path only; REST-only profile/skills/image-upload surfaces remain unavailable. |
-| Hermes Web full view | Local/Remote API alpha | Requires a token-backed Local or Remote API connection. Cloud Preview and ticketed remote-dashboard transports remain Chat-only in the side panel. |
+| Self-hosted remote dashboard WebSocket | Best-effort | Select Remote gateway with an HTTPS dashboard URL and no API key. Chat/session/model path plus opt-in context sharing; REST-only profile/skills/image-upload surfaces remain unavailable. |
+| Hermes Web full view | Local/Remote API alpha | Requires a token-backed Local or Remote API connection. Cloud Preview and ticketed remote-dashboard transports are Chat-only by default with opt-in context sharing in the side panel. |
 | Browser Context Protocol | Yes | Extension emits typed `hermes.browser.context.v2` turn envelopes while retaining the v1 prompt compatibility path. |
 | Hermes Assist | Yes, site-aware preview/review | 31 writing environments are recognized. Safe plain-text composers may apply after explicit review; structured/private surfaces can fall back to copy-only. Hermes Assist never submits. |
 | Companion plugin | Optional functional context cache | `companion-plugin/` provides read-only tools/hooks for sanitized Browser context; not required for normal extension use. |
@@ -237,7 +237,7 @@ Hermes Cloud Preview uses **Trusted Dashboard Attach**:
 
 The extension binds trust to that exact active tab and HTTPS origin, verifies the tab again before minting, mints a short-lived single-use WebSocket ticket in the page, and verifies the WebSocket handshake before reporting success. The ticket is kept in memory only and is never persisted or logged. Cloud never falls back to localhost or a stored Local API token.
 
-Hermes Cloud is **Chat-only** in this release. Browser page text, selected text, open-tab context, and attachments are disabled for this mode. The extension does not read dashboard cookies, store a Cloud password, or add `cookies` or `nativeMessaging` permissions.
+Hermes Cloud is **Chat-only by default** in this release; enabling **Share page context with this gateway** in Settings (a per-connection consent toggle, off by default because the endpoint is a third party) unlocks Follow active tab, Pin current tab, per-tab prompt selection, and full BCP v2 page context over the dashboard WebSocket. Browser page text, selected text, and open-tab context stay disabled until you opt in, and the extension still does not read dashboard cookies, store a Cloud password, or add `cookies` or `nativeMessaging` permissions.
 
 If the connected Cloud agent does not expose `/api/auth/ws-ticket`, `/api/ws`, or the required session/model RPC methods, the extension reports the missing capability and leaves Local/Remote settings untouched. Update that agent's Hermes runtime using the [official Hermes Agent installation and update docs](https://hermes-agent.nousresearch.com/docs/getting-started/installation). It never redirects Cloud to `127.0.0.1` as a fallback.
 

--- a/companion-plugin/context_store.py
+++ b/companion-plugin/context_store.py
@@ -249,6 +249,48 @@ class BrowserContextStore:
             )
             return self._metadata(record)
 
+    def put_bcp_v2_payload(self, payload: dict[str, Any], owner: ContextOwner) -> dict[str, Any]:
+        """Store one pre-validated BCP v2 context payload from the WS upload RPC.
+
+        The extension already validated and budget-capped the envelope before
+        sending it; this path still fail-closes on shape and size, binds the
+        record to the trusted execution owner, and reuses the same TTL/LRU
+        lifecycle as message-sourced records.
+        """
+        if not isinstance(payload, dict) or payload.get("protocol") != BCP_CONTEXT_PROTOCOL_ID:
+            return dict(_UNAVAILABLE)
+        try:
+            serialized = json.dumps(payload, default=str)
+        except (TypeError, ValueError):
+            return dict(_UNAVAILABLE)
+        if len(serialized) > _MAX_BCP_TURN_CHARS:
+            return dict(_UNAVAILABLE)
+        context_scope = payload.get("contextScope")
+        scope = context_scope.get("mode", "unknown") if isinstance(context_scope, dict) else "unknown"
+        now = self._now()
+        ttl = max(0.0, float(self.ttl_seconds))
+        record = BrowserContextRecord(
+            context_id=secrets.token_hex(16),
+            owner=owner,
+            payload=deepcopy(payload),
+            provenance={"protocol": "hermes.browser.upload.v1", "delivery": "upload", "context_hash": ""},
+            payload_hash=str(payload.get("context_hash") or "")[:80],
+            scope=str(scope)[:80] or "unknown",
+            created_at=now,
+            expires_at=now + ttl,
+        )
+        with self._lock:
+            self._prune_expired_locked(now)
+            self._records[record.context_id] = record
+            self._evict_locked()
+            self._record_event_locked(
+                "browser.context.uploaded",
+                {"protocol": record.provenance["protocol"], "scope": record.scope},
+                owner,
+                now,
+            )
+            return self._metadata(record)
+
     def status_for_owner(self, owner: ContextOwner) -> dict[str, Any]:
         """Return current-owner metadata only; this never consumes payload."""
         now = self._now()

--- a/companion-plugin/hooks.py
+++ b/companion-plugin/hooks.py
@@ -91,6 +91,41 @@ def _owner_from_trusted_hook(**kwargs: Any) -> ContextOwner | None:
     return owner_from_hook_kwargs(kwargs)
 
 
+def handle_ws_method(method: str, params: dict[str, Any] | None, **kwargs: Any) -> dict[str, Any] | None:
+    """Handle dashboard-WebSocket ``browser.*`` RPCs routed by Hermes core.
+
+    Inert on cores without WS-to-plugin dispatch: the extension treats an
+    unknown-method error as \"upload unsupported\" and stays on full inline
+    delivery, so this hook failing closed is always safe.
+    """
+    if method not in ("browser.context.upload", "browser.events.publish"):
+        return None
+    owner = _owner_from_trusted_hook(**kwargs)
+    if owner is None:
+        return {"ok": False, "error": "unowned-rpc"}
+
+    if method == "browser.events.publish":
+        events = params.get("events") if isinstance(params, dict) else None
+        if not isinstance(events, list):
+            return {"ok": False, "error": "invalid-events"}
+        store = _ensure_store()
+        for item in events[:20]:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("type") or "browser.event")[:120]
+            data = {key: value for key, value in item.items() if key != "type"}
+            store.record_event(name, data, owner)
+        return {"ok": True, "count": min(len(events), 20)}
+
+    payload = params.get("payload") if isinstance(params, dict) else None
+    if not isinstance(payload, dict):
+        return {"ok": False, "error": "invalid-payload"}
+    status = _ensure_store().put_bcp_v2_payload(payload, owner)
+    if not status.get("available"):
+        return {"ok": False, "error": "storage-unavailable"}
+    return {"ok": True, "status": status}
+
+
 def pre_llm_call(**kwargs: Any) -> dict[str, str] | None:
     """Cache only a valid BCP v2 full-context envelope for this trusted turn."""
     try:

--- a/companion-plugin/plugin.yaml
+++ b/companion-plugin/plugin.yaml
@@ -21,3 +21,4 @@ provides_hooks:
   - pre_llm_call
   - pre_tool_call
   - post_tool_call
+  - handle_ws_method

--- a/extension/lib/common.mjs
+++ b/extension/lib/common.mjs
@@ -57,6 +57,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   tokenSource: '',
   lastConnectionTestedAt: 0,
   shareBrowserContext: false,
+  allowBrowserControl: false,
   sessionId: 'hermes-browser-extension',
   sessionTitle: 'Hermes Browser Extension',
   sessionSource: 'hermes_browser',

--- a/extension/lib/gateway-ws.mjs
+++ b/extension/lib/gateway-ws.mjs
@@ -29,6 +29,9 @@ export const WS_METHODS = Object.freeze({
   voiceRecord: 'voice.record',
   voiceTts: 'voice.tts',
   configSet: 'config.set',
+  browserContextUpload: 'browser.context.upload',
+  browserEventsPublish: 'browser.events.publish',
+  browserControlResult: 'browser.control.result',
 });
 
 // Streamed assistant-turn events we care about. Everything else (tool.*,
@@ -42,6 +45,12 @@ export const WS_EVENTS = Object.freeze({
   voiceTranscript: 'voice.transcript',
   voiceStatus: 'voice.status',
   error: 'error',
+  // Server→client capability events for the browser companion surface. These
+  // ride the existing `method === 'event'` frame with a typed `params.type`,
+  // so older cores that never emit them are harmless (extension stays in
+  // inline/full delivery mode).
+  browserControl: 'browser.control',
+  fileDelivery: 'file.delivery',
 });
 
 // Gateway sessions have two identities. `session_id` addresses the live

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -4346,3 +4346,51 @@ h2,
   .task-stack-progress i,
   .task-stack-chevron { transition: none; }
 }
+
+/* ── Agent → extension file delivery (Phase 6) ─────────────────────────── */
+.file-delivery-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 6px 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border, rgba(128, 128, 128, .35));
+  border-radius: 8px;
+  background: var(--bg-elevated, rgba(128, 128, 128, .08));
+}
+.file-delivery-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+/* ── Browser control approval (Phase 4) ────────────────────────────────── */
+.browser-control-approval-card {
+  margin: 6px 0;
+  padding: 8px 10px;
+  border: 1px solid var(--accent, rgba(100, 160, 255, .45));
+  border-radius: 8px;
+  background: var(--bg-elevated, rgba(128, 128, 128, .08));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.browser-control-approval-copy {
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+.browser-control-approval-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.browser-control-approval-auto {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  margin-left: auto;
+}

--- a/extension/sidepanel.html
+++ b/extension/sidepanel.html
@@ -643,6 +643,15 @@
             <span class="settings-switch" aria-hidden="true"></span>
           </label>
 
+          <label class="settings-toggle-card" id="allowBrowserControlControl" hidden>
+            <span class="settings-toggle-copy">
+              <strong data-i18n="ui.allow.browser.control">Allow Hermes to control this browser</strong>
+              <small data-i18n="ui.allow.browser.control.detail">Let Hermes navigate, click, type, and read pages in your active tab. Every action asks for your approval first.</small>
+            </span>
+            <input id="allowBrowserControlInput" class="settings-switch-input" type="checkbox" />
+            <span class="settings-switch" aria-hidden="true"></span>
+          </label>
+
           <fieldset class="panel-residency-options settings-choice-group">
             <legend data-i18n="ui.panel.opening">Panel opening</legend>
             <div class="settings-choice-grid">

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -112,7 +112,7 @@ import {
   buildAssistModelRouteRequest,
   resolveAssistModelBindingFromCatalog,
 } from './lib/assist-model-contract.mjs';
-import { serializeBrowserTurnEnvelope } from './lib/browser-context-protocol.mjs';
+import { buildBrowserTurnEnvelope, serializeBrowserTurnEnvelope } from './lib/browser-context-protocol.mjs';
 import {
   APPEARANCE_THEMES,
   normalizeAppearanceTheme,
@@ -433,6 +433,8 @@ const els = {
   includeSelectedTextInput: $('#includeSelectedTextInput'),
   shareBrowserContextInput: $('#shareBrowserContextInput'),
   shareBrowserContextControl: $('#shareBrowserContextControl'),
+  allowBrowserControlInput: $('#allowBrowserControlInput'),
+  allowBrowserControlControl: $('#allowBrowserControlControl'),
   inlineAssistEnabled: $('#inlineAssistEnabled'),
   inlineAssistDefaultRoute: $('#inlineAssistDefaultRoute'),
   inlineAssistModel: $('#inlineAssistModel'),
@@ -1686,6 +1688,7 @@ async function loadGatewayCapabilities({ quiet = false, publicOnly = false, heal
       skills: true,
       dashboardWs: true,
       browserContextInline: settings.shareBrowserContext === true,
+      browserControl: settings.allowBrowserControl === true,
       warnings: [
         'Remote dashboard mode uses WebSocket session/chat APIs; REST-only browser extension APIs stay unavailable.',
         'Voice transcription unavailable — using browser speech fallback when available.',
@@ -1743,6 +1746,11 @@ function renderShareBrowserContextControl() {
   const relevant = mode === 'cloud' || settings.connectionTransport === CONNECTION_TRANSPORTS.REMOTE_DASHBOARD;
   els.shareBrowserContextControl.hidden = !relevant;
   if (relevant) els.shareBrowserContextInput.checked = settings.shareBrowserContext === true;
+  if (els.allowBrowserControlControl && els.allowBrowserControlInput) {
+    const sharing = relevant && settings.shareBrowserContext === true;
+    els.allowBrowserControlControl.hidden = !sharing;
+    if (sharing) els.allowBrowserControlInput.checked = settings.allowBrowserControl === true;
+  }
 }
 
 function applyConnectionMode(value) {
@@ -6417,6 +6425,9 @@ async function loadSettings({ restoreMessages = false } = {}) {
     shareBrowserContext: typeof settings.shareBrowserContext === 'boolean'
       ? settings.shareBrowserContext
       : deriveShareBrowserContextDefault(settings),
+    // Browser control is opt-in on top of context sharing and always starts
+    // disabled for existing installs.
+    allowBrowserControl: settings.allowBrowserControl === true,
   };
   trustedDashboardTabId = Number(settings.trustedDashboardTabId) || null;
   contextScope = contextScopeForGateway(contextScope, settings.gatewayMode, { shareBrowserContext: settings.shareBrowserContext === true });
@@ -6478,6 +6489,7 @@ function syncSettingsForm() {
   els.includePageTextInput.checked = Boolean(settings.includePageText);
   els.includeSelectedTextInput.checked = Boolean(settings.includeSelectedText);
   if (els.shareBrowserContextInput) els.shareBrowserContextInput.checked = settings.shareBrowserContext === true;
+  if (els.allowBrowserControlInput) els.allowBrowserControlInput.checked = settings.allowBrowserControl === true;
   renderShareBrowserContextControl();
   if (els.inlineAssistEnabled) els.inlineAssistEnabled.checked = settings.inlineAssistEnabled !== false;
   if (els.inlineAssistDefaultRoute) els.inlineAssistDefaultRoute.value = normalizeInlineDraftRoutePreference(settings.inlineAssistDefaultRoute);
@@ -6564,6 +6576,9 @@ async function saveSettingsFromForm() {
     shareBrowserContext: shareContextRelevant && els.shareBrowserContextInput
       ? els.shareBrowserContextInput.checked
       : settings.shareBrowserContext === true,
+    allowBrowserControl: shareContextRelevant && els.allowBrowserControlInput
+      ? els.allowBrowserControlInput.checked
+      : settings.allowBrowserControl === true,
     inlineAssistEnabled: els.inlineAssistEnabled ? els.inlineAssistEnabled.checked : settings.inlineAssistEnabled !== false,
     inlineAssistDefaultRoute: normalizeInlineDraftRoutePreference(els.inlineAssistDefaultRoute?.value || settings.inlineAssistDefaultRoute),
     ...assistBinding,
@@ -7526,6 +7541,12 @@ async function ensureRemoteWsClient() {
     throw error;
   }
   const connection = { client, baseUrl, wsSessionId: '', wsStoredSessionId: '' };
+  client.on(WS_EVENTS.fileDelivery, (event) => handleFileDeliveryEvent(event).catch((error) => {
+    console.warn('[Hermes Browser] File delivery failed:', error?.message || error);
+  }));
+  client.on(WS_EVENTS.browserControl, (event) => handleBrowserControlEvent(event).catch((error) => {
+    console.warn('[Hermes Browser] Browser control failed:', error?.message || error);
+  }));
   client.on('close', () => {
     if (remoteWsConnection === connection) {
       remoteWsConnection = null;
@@ -8067,6 +8088,292 @@ async function fallbackChatCompletions(prompt, turnAttachments = attachments) {
   return extractAssistantText(payload);
 }
 
+// ── Dashboard browser-context upload (Phase 2) ────────────────────────────
+// When a Cloud/dashboard connection shares context, the full BCP envelope is
+// also pushed out-of-band to the companion plugin store (debounced) so later
+// turns can send hash references instead of re-sending page text. Cores
+// without the RPC reject it; we then fall back to full inline delivery for
+// every subsequent turn so the agent never misses context.
+let browserContextUploadAvailable = true;
+let browserContextUploadTimer = null;
+let pendingBrowserContextUpload = null;
+
+function pushBrowserContextUpload(envelope) {
+  if (!isRemoteWsMode() || settings.shareBrowserContext !== true || browserContextUploadAvailable === false) return;
+  if (!envelope || typeof envelope !== 'object') return;
+  pendingBrowserContextUpload = envelope;
+  clearTimeout(browserContextUploadTimer);
+  browserContextUploadTimer = setTimeout(() => {
+    const payload = pendingBrowserContextUpload;
+    pendingBrowserContextUpload = null;
+    const client = remoteWsConnection?.client;
+    const sessionId = remoteWsConnection?.wsStoredSessionId || remoteWsConnection?.wsSessionId;
+    if (!client || !sessionId) return;
+    client.request(WS_METHODS.browserContextUpload, {
+      session_id: sessionId,
+      context_hash: String(
+        envelope?.source_receipt?.context_hash
+        || envelope?.browser_context?.payload?.context_hash
+        || '',
+      ),
+      payload,
+    }).catch(() => {
+      // Core does not support out-of-band upload: stay on full inline delivery.
+      browserContextUploadAvailable = false;
+    });
+  }, 800);
+}
+
+// ── Dashboard file delivery (Phase 6) ────────────────────────────────────
+// Server→client `file.delivery` events carry base64 file bytes; render a
+// download card and save via chrome.downloads (already in the manifest).
+const MAX_DASHBOARD_FILE_BYTES = 4 * 1024 * 1024;
+
+async function handleFileDeliveryEvent(event) {
+  const payload = event?.payload || {};
+  const name = String(payload.name || 'hermes-file');
+  const mime = String(payload.mime || 'application/octet-stream');
+  const data = String(payload.data || '');
+  if (!data) return;
+  let bytes;
+  try {
+    bytes = Uint8Array.from(atob(data), (char) => char.charCodeAt(0));
+  } catch {
+    setStatus('warn', 'File delivery failed', 'Malformed file payload from the gateway.');
+    return;
+  }
+  if (bytes.byteLength > MAX_DASHBOARD_FILE_BYTES) {
+    setStatus('warn', 'File too large', 'This gateway can only deliver files up to 4 MiB.');
+    return;
+  }
+  appendFileDeliveryCard({ name, mime, bytes });
+}
+
+function appendFileDeliveryCard({ name, mime, bytes }) {
+  const { node } = addMessage('system', '', { persist: false });
+  const content = node.querySelector('.message-content') || node;
+  const card = document.createElement('div');
+  card.className = 'file-delivery-card';
+  const label = document.createElement('span');
+  label.className = 'file-delivery-label';
+  label.textContent = `📎 ${name} · ${formatBytes(bytes.byteLength)}`;
+  const save = document.createElement('button');
+  save.type = 'button';
+  save.className = 'primary tiny';
+  save.textContent = translateUiText('Download');
+  save.addEventListener('click', () => saveDeliveredFile({ name, mime, bytes }));
+  card.append(label, save);
+  content.appendChild(card);
+  node.scrollIntoView?.({ block: 'nearest' });
+}
+
+async function saveDeliveredFile({ name, mime, bytes }) {
+  const blob = new Blob([bytes], { type: mime });
+  const dataUrl = URL.createObjectURL(blob);
+  const fallback = () => {
+    if (bytes.byteLength <= 512 * 1024) {
+      navigator.clipboard?.writeText(new TextDecoder().decode(bytes)).catch(() => {});
+    }
+    const link = document.createElement('a');
+    link.href = dataUrl;
+    link.download = name;
+    link.click();
+  };
+  if (chrome.downloads?.download) {
+    chrome.downloads.download({ url: dataUrl, filename: name }, () => {
+      if (chrome.runtime?.lastError) fallback();
+    });
+  } else {
+    fallback();
+  }
+}
+
+// ── Browser control (Phase 4) ────────────────────────────────────────────
+// Server→client `browser.control` events ask the extension to drive the
+// active tab. Every action is gated by (a) context-sharing consent,
+// (b) the explicit allowBrowserControl setting, and (c) an inline per-action
+// approval card (with a session-scoped auto-approve). Results are correlated
+// back to the core via the `browser.control.result` RPC using the request_id.
+const BROWSER_CONTROL_ACTIONS = new Set(['navigate', 'click', 'type', 'scroll', 'snapshot', 'extract']);
+let browserControlAutoApprove = false;
+
+async function handleBrowserControlEvent(event) {
+  const payload = event?.payload || {};
+  const requestId = String(payload.request_id || '');
+  const action = String(payload.action || '');
+  if (!requestId || !BROWSER_CONTROL_ACTIONS.has(action)) return;
+  if (settings.shareBrowserContext !== true || settings.allowBrowserControl !== true) {
+    replyBrowserControl(requestId, false, 'browser control is disabled (enable it in Settings with context sharing on)');
+    return;
+  }
+  const approved = await requestBrowserControlApproval(action, payload.params || {});
+  if (!approved) {
+    replyBrowserControl(requestId, false, 'user declined the control request');
+    return;
+  }
+  try {
+    const result = await executeBrowserControl(action, payload.params || {});
+    replyBrowserControl(requestId, true, result);
+  } catch (error) {
+    const message = error?.message || String(error);
+    replyBrowserControl(requestId, false, message);
+  }
+}
+
+function replyBrowserControl(requestId, ok, resultOrError) {
+  const client = remoteWsConnection?.client;
+  if (!client || !requestId) return;
+  const body = ok ? { ok: true, result: resultOrError } : { ok: false, error: String(resultOrError || 'control failed') };
+  client.request(WS_METHODS.browserControlResult, { request_id: requestId, ...body }).catch(() => {});
+}
+
+function requestBrowserControlApproval(action, params) {
+  if (browserControlAutoApprove) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const { node } = addMessage('system', '', { persist: false });
+    const content = node.querySelector('.message-content') || node;
+    const card = document.createElement('div');
+    card.className = 'browser-control-approval-card';
+    const copy = document.createElement('div');
+    copy.className = 'browser-control-approval-copy';
+    const target = params.selector ? ` ${params.selector}` : params.url ? ` ${params.url}` : '';
+    copy.textContent = `Hermes wants to ${action}${target}`;
+    const row = document.createElement('div');
+    row.className = 'browser-control-approval-actions';
+    const accept = document.createElement('button');
+    accept.type = 'button';
+    accept.className = 'primary tiny';
+    accept.textContent = translateUiText('Approve');
+    const decline = document.createElement('button');
+    decline.type = 'button';
+    decline.className = 'secondary tiny';
+    decline.textContent = translateUiText('Decline');
+    const auto = document.createElement('label');
+    auto.className = 'browser-control-approval-auto';
+    const autoInput = document.createElement('input');
+    autoInput.type = 'checkbox';
+    auto.append(autoInput, document.createTextNode(` ${translateUiText('Approve for this session')}`));
+    const settle = (value) => {
+      if (autoInput.checked) browserControlAutoApprove = true;
+      card.remove();
+      resolve(value);
+    };
+    accept.addEventListener('click', () => settle(true));
+    decline.addEventListener('click', () => settle(false));
+    row.append(accept, decline, auto);
+    card.append(copy, row);
+    content.appendChild(card);
+    node.scrollIntoView?.({ block: 'nearest' });
+  });
+}
+
+function controlSnapshotInPage() {
+  const interactive = [...document.querySelectorAll('a,button,input,select,textarea,[role="button"],summary')]
+    .slice(0, 120)
+    .map((el) => {
+      const label = (el.getAttribute('aria-label') || el.innerText || el.value || el.placeholder || el.textContent || '').trim().slice(0, 120);
+      return { tag: el.tagName.toLowerCase(), label };
+    })
+    .filter((item) => item.label);
+  return { title: document.title, url: location.href, text: (document.body?.innerText || '').slice(0, 12000), interactive };
+}
+
+function controlClickInPage(selector) {
+  const el = document.querySelector(selector);
+  if (!el) return { ok: false, error: `no element for selector: ${selector}` };
+  el.scrollIntoView({ block: 'center' });
+  el.click();
+  return { ok: true };
+}
+
+function controlTypeInPage(selector, text) {
+  const el = document.querySelector(selector);
+  if (!el) return { ok: false, error: `no element for selector: ${selector}` };
+  if (el.tagName === 'INPUT' && String(el.type || '').toLowerCase() === 'password') {
+    return { ok: false, error: 'refusing to type into a password field' };
+  }
+  const proto = el instanceof HTMLTextAreaElement
+    ? HTMLTextAreaElement.prototype
+    : el instanceof HTMLInputElement
+      ? HTMLInputElement.prototype
+      : null;
+  if (!proto) return { ok: false, error: 'target is not an input or textarea' };
+  Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, String(text));
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  el.dispatchEvent(new Event('change', { bubbles: true }));
+  return { ok: true };
+}
+
+function controlScrollInPage(direction, delta) {
+  const amount = Number(delta) || Math.round(window.innerHeight * 0.8);
+  window.scrollBy({ top: direction === 'up' ? -amount : amount, behavior: 'smooth' });
+  return { ok: true, scrollY: window.scrollY };
+}
+
+function controlExtractInPage(selector) {
+  const el = document.querySelector(selector);
+  if (!el) return { ok: false, error: `no element for selector: ${selector}` };
+  return { ok: true, text: (el.innerText || el.textContent || '').trim().slice(0, 12000) };
+}
+
+async function executeBrowserControl(action, params) {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  const tabId = tabs[0]?.id;
+  if (!tabId) throw new Error('no active tab');
+  if (action === 'navigate') {
+    const url = String(params.url || '').trim();
+    if (!/^https?:\/\//i.test(url)) throw new Error('refusing to navigate to a non-http(s) URL');
+    if (isRestrictedUrl(url)) throw new Error('refusing to navigate to a restricted URL');
+    await chrome.tabs.update(tabId, { url });
+    return { ok: true, url };
+  }
+  const target = { tabId };
+  if (action === 'snapshot') {
+    const [{ result }] = await chrome.scripting.executeScript({ target, func: controlSnapshotInPage });
+    return { ok: true, result };
+  }
+  if (action === 'click') {
+    const [{ result }] = await chrome.scripting.executeScript({ target, func: controlClickInPage, args: [String(params.selector || '')] });
+    return result;
+  }
+  if (action === 'type') {
+    const [{ result }] = await chrome.scripting.executeScript({ target, func: controlTypeInPage, args: [String(params.selector || ''), String(params.text ?? '')] });
+    return result;
+  }
+  if (action === 'scroll') {
+    const [{ result }] = await chrome.scripting.executeScript({ target, func: controlScrollInPage, args: [params.direction === 'up' ? 'up' : 'down', Number(params.delta) || 0] });
+    return result;
+  }
+  if (action === 'extract') {
+    const [{ result }] = await chrome.scripting.executeScript({ target, func: controlExtractInPage, args: [String(params.selector || '')] });
+    return result;
+  }
+  throw new Error(`unsupported action: ${action}`);
+}
+
+// ── Dashboard browser-event publishing (Phase 3) ──────────────────────────
+// Tab/page lifecycle events are pushed to the gateway as best-effort metadata
+// (never page text). Cores without the RPC simply ignore it.
+let browserEventsPublishTimer = null;
+let pendingBrowserEvents = [];
+
+function publishBrowserEvents(events) {
+  if (!isRemoteWsMode() || settings.shareBrowserContext !== true) return;
+  const fresh = (Array.isArray(events) ? events : []).filter(Boolean);
+  if (!fresh.length) return;
+  pendingBrowserEvents.push(...fresh);
+  clearTimeout(browserEventsPublishTimer);
+  browserEventsPublishTimer = setTimeout(() => {
+    const batch = pendingBrowserEvents;
+    pendingBrowserEvents = [];
+    const client = remoteWsConnection?.client;
+    const sessionId = remoteWsConnection?.wsStoredSessionId || remoteWsConnection?.wsSessionId;
+    if (!client || !sessionId || !batch.length) return;
+    client.request(WS_METHODS.browserEventsPublish, { session_id: sessionId, events: batch })
+      .catch(() => { /* best-effort metadata */ });
+  }, 600);
+}
+
 async function askHermes(userText, turnAttachments = [...attachments], turnOptions = {}) {
   if (!isConnected()) {
     updateConnectionPrompt();
@@ -8164,10 +8471,11 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
       contextHash,
       previous: contextDeliveryBySession.get(contextDeliverySessionKey) || null,
     });
-    const contextDelivery = (turnOptions.forceFullContext || forceFullContextNextTurn) && deliveryDecision.mode !== CONTEXT_DELIVERY_MODES.NONE
+    const uploadUnavailable = isRemoteWsMode() && settings.shareBrowserContext === true && browserContextUploadAvailable === false;
+    const contextDelivery = (turnOptions.forceFullContext || forceFullContextNextTurn || uploadUnavailable) && deliveryDecision.mode !== CONTEXT_DELIVERY_MODES.NONE
       ? CONTEXT_DELIVERY_MODES.FULL
       : deliveryDecision.mode;
-    const prompt = serializeBrowserTurnEnvelope({
+    const envelope = buildBrowserTurnEnvelope({
       humanInput: promptUserText,
       instructionTransform: parsedCommand ? { kind: 'slash-command', text: basePromptText } : null,
       activeTab: context.activeTab,
@@ -8180,6 +8488,10 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
       contextHash,
       contextDelivery,
     });
+    const prompt = JSON.stringify(envelope);
+    if (contextDelivery === CONTEXT_DELIVERY_MODES.FULL && turnContextScope.mode !== CONTEXT_SCOPE_MODES.CHAT_ONLY) {
+      pushBrowserContextUpload(envelope);
+    }
 
     const receipt = buildContextReceipt({
       context,
@@ -9589,13 +9901,18 @@ function bindEvents() {
   });
   chrome.tabs?.onActivated?.addListener?.((activeInfo) => {
     if (shouldRefreshForTabEvent({ scope: contextScope, eventType: 'activated', eventTabId: activeInfo?.tabId })) refreshContext();
+    publishBrowserEvents([{ type: 'tab.activated', tab_id: activeInfo?.tabId, ts: Date.now() }]);
   });
   chrome.tabs?.onUpdated?.addListener?.((tabId, changeInfo) => {
     if (!(changeInfo.status === 'complete' || changeInfo.title || changeInfo.url)) return;
     if (shouldRefreshForTabEvent({ scope: contextScope, eventType: 'updated', eventTabId: tabId })) refreshContext();
+    if (changeInfo.status === 'complete') {
+      publishBrowserEvents([{ type: 'tab.updated', tab_id: tabId, title: String(changeInfo.title || '').slice(0, 240), ts: Date.now() }]);
+    }
   });
   chrome.tabs?.onRemoved?.addListener?.((tabId) => {
     if (shouldRefreshForTabEvent({ scope: contextScope, eventType: 'removed', eventTabId: tabId })) refreshContext();
+    publishBrowserEvents([{ type: 'tab.removed', tab_id: tabId, ts: Date.now() }]);
   });
   chrome.runtime?.onMessage?.addListener?.((message, _sender, sendResponse) => {
     if (message?.type === WAKE_MESSAGES.localState) {

--- a/tests/browser-context-protocol.test.mjs
+++ b/tests/browser-context-protocol.test.mjs
@@ -403,9 +403,9 @@ test('BCP v2 final redaction fails closed on unsupported values and cycles', () 
 
 test('BCP v2 sidepanel transport passes prepared attachments into the typed envelope', () => {
   const sidepanelSource = readFileSync(new URL('../extension/sidepanel.js', import.meta.url), 'utf8');
-  const callStart = sidepanelSource.indexOf('serializeBrowserTurnEnvelope({');
+  const callStart = sidepanelSource.indexOf('buildBrowserTurnEnvelope({');
   const callEnd = sidepanelSource.indexOf('\n    });', callStart);
-  assert.ok(callStart >= 0 && callEnd > callStart, 'serializer call must be present and bounded');
+  assert.ok(callStart >= 0 && callEnd > callStart, 'envelope builder call must be present and bounded');
   const serializerCall = sidepanelSource.slice(callStart, callEnd);
   assert.match(serializerCall, /humanInput:\s*promptUserText/);
   assert.match(serializerCall, /attachments:\s*preparedAttachments/);

--- a/tests/companion-plugin.test.mjs
+++ b/tests/companion-plugin.test.mjs
@@ -285,6 +285,75 @@ assert parse_bcp_v2_turn("x" * 64001) is None
   runPluginPython(script);
 });
 
+test('context_store accepts pre-validated upload payloads with owner scoping', () => {
+  const script = `${pluginImportHarness}
+import json
+from companion_plugin.context_store import BrowserContextStore, owner_from_hook_kwargs, BCP_CONTEXT_PROTOCOL_ID
+
+def owner(turn):
+    return owner_from_hook_kwargs({"platform": "telegram", "sender_id": "sender", "session_id": "session", "turn_id": turn, "task_id": "task"})
+
+def payload(label):
+    return {
+        "protocol": BCP_CONTEXT_PROTOCOL_ID,
+        "contextScope": {"mode": "pinned-tab"},
+        "settings": {},
+        "activeTab": {"url": "https://example.com"},
+        "tabs": [],
+        "selectedTabs": [],
+        "pageContext": {"text": label},
+        "context_hash": "deadbeef",
+    }
+
+store = BrowserContextStore(ttl_seconds=30, max_entries=2, max_entries_per_principal=2)
+first = store.put_bcp_v2_payload(payload("one"), owner("turn-1"))
+assert first["available"] is True
+assert first["scope"] == "pinned-tab"
+second = store.put_bcp_v2_payload(payload("two"), owner("turn-2"))
+assert second["available"] is True
+consumed = store.consume_for_owner(second["context_id"], owner("turn-2"))
+assert consumed["payload"]["pageContext"]["text"] == "two"
+# Wrong owner cannot consume another principal's record.
+assert store.consume_for_owner(first["context_id"], owner("turn-2")) is None
+# Fail-closed on shape and size.
+assert store.put_bcp_v2_payload({"protocol": "nope"}, owner("turn-1"))["available"] is False
+assert store.put_bcp_v2_payload({}, owner("turn-1"))["available"] is False
+oversize = payload("x" * 64001)
+assert store.put_bcp_v2_payload(oversize, owner("turn-1"))["available"] is False
+`;
+  runPluginPython(script);
+});
+
+test('handle_ws_method routes uploads and events and fails closed', () => {
+  const script = `${pluginImportHarness}
+from companion_plugin import hooks
+from companion_plugin.context_store import owner_from_hook_kwargs, BCP_CONTEXT_PROTOCOL_ID
+
+hooks.set_store(__import__("companion_plugin.context_store", fromlist=["BrowserContextStore"]).BrowserContextStore(ttl_seconds=30))
+
+def owner_kwargs(turn):
+    return {"platform": "telegram", "sender_id": "sender", "session_id": "session", "turn_id": turn, "task_id": "task"}
+
+owner = owner_from_hook_kwargs(owner_kwargs("turn-1"))
+# Unknown methods are ignored (return None) so other handlers can claim them.
+assert hooks.handle_ws_method("something.else", {}, **owner_kwargs("turn-1")) is None
+# Events publish records metadata without page text.
+result = hooks.handle_ws_method("browser.events.publish", {"events": [{"type": "tab.activated", "tab_id": 7}]}, **owner_kwargs("turn-1"))
+assert result == {"ok": True, "count": 1}
+assert hooks.handle_ws_method("browser.events.publish", {"events": "bad"}, **owner_kwargs("turn-1")) == {"ok": False, "error": "invalid-events"}
+# Upload stores the payload for the owning execution.
+upload = hooks.handle_ws_method("browser.context.upload", {"context_hash": "cafe", "payload": {
+    "protocol": BCP_CONTEXT_PROTOCOL_ID,
+    "contextScope": {"mode": "follow-active"},
+    "settings": {}, "activeTab": {}, "tabs": [], "selectedTabs": [], "pageContext": {"text": "uploaded"},
+}}, **owner_kwargs("turn-1"))
+assert upload["ok"] is True and upload["status"]["available"] is True
+# Malformed uploads fail closed.
+assert hooks.handle_ws_method("browser.context.upload", {"payload": "nope"}, **owner_kwargs("turn-1")) == {"ok": False, "error": "invalid-payload"}
+`;
+  runPluginPython(script);
+});
+
 test('browser_event_log clamps invalid limits without crashing', () => {
   const script = `${pluginImportHarness}
 from companion_plugin import tools

--- a/tests/gateway-ws.test.mjs
+++ b/tests/gateway-ws.test.mjs
@@ -13,6 +13,7 @@ import {
   remoteSessionIdentity,
   remoteStoredSessionIdForGateway,
   runtimeModelFromSessionStatus,
+  WS_EVENTS,
   WS_METHODS,
 } from '../extension/lib/gateway-ws.mjs';
 
@@ -157,6 +158,14 @@ test('WS_METHODS exposes Desktop/TUI session steering instead of slash-command i
   assert.equal(WS_METHODS.promptSubmit, 'prompt.submit');
 });
 
+test('WS_METHODS and WS_EVENTS expose the browser companion surface', () => {
+  assert.equal(WS_METHODS.browserContextUpload, 'browser.context.upload');
+  assert.equal(WS_METHODS.browserEventsPublish, 'browser.events.publish');
+  assert.equal(WS_METHODS.browserControlResult, 'browser.control.result');
+  assert.equal(WS_EVENTS.browserControl, 'browser.control');
+  assert.equal(WS_EVENTS.fileDelivery, 'file.delivery');
+});
+
 test('remoteSessionIdentity keeps live and durable ids distinct', () => {
   assert.deepEqual(
     remoteSessionIdentity({ session_id: 'live-A', stored_session_id: 'stored-A' }),
@@ -283,6 +292,17 @@ test('classifyGatewayFrame distinguishes responses, errors, events, and noise', 
   );
   assert.equal(classifyGatewayFrame('not json').kind, 'ignore');
   assert.equal(classifyGatewayFrame({ method: 'event', params: {} }).kind, 'ignore');
+});
+
+test('classifyGatewayFrame routes browser control and file delivery as typed events', () => {
+  assert.deepEqual(
+    classifyGatewayFrame({ method: 'event', params: { type: 'browser.control', session_id: 's1', payload: { request_id: 'r1', action: 'snapshot' } } }),
+    { kind: 'event', type: 'browser.control', sessionId: 's1', payload: { request_id: 'r1', action: 'snapshot' } },
+  );
+  assert.deepEqual(
+    classifyGatewayFrame({ method: 'event', params: { type: 'file.delivery', session_id: 's1', payload: { name: 'plan.md', data: 'aGk=' } } }),
+    { kind: 'event', type: 'file.delivery', sessionId: 's1', payload: { name: 'plan.md', data: 'aGk=' } },
+  );
 });
 
 test('gateway client connects, resolves a matching RPC response, and dispatches events', async () => {


### PR DESCRIPTION
## Stacked on #66 — read that first

This PR builds **directly on top of [#66 (Phase 0: opt-in browser-context sharing)](https://github.com/abundantbeing/hermes-browser-extension/pull/66)**, which lands the `shareBrowserContext` consent setting and de-gates `contextScopeForGateway()`. Its base is the Phase 0 branch, so **review the diff as the delta on top of #66**; once #66 merges, retarget this one to `main`.

## What this adds (Phases 2–7 of the parity plan)

| Phase | Feature | Extension | Companion plugin | Needs core? |
|---|---|---|---|---|
| **2** | **On-demand context pull** — `browser.context.upload` RPC (debounced out-of-band envelope push) enabling hash-reference turns; **auto-falls back to full inline delivery** if the core rejects the RPC | ✅ | ✅ `put_bcp_v2_payload` + `handle_ws_method` | WS→plugin dispatch (`handle_ws_method` hook) |
| **3** | **Live browser events** — `browser.events.publish` for tab/page lifecycle metadata (never page text), recorded into the owner-scoped event log | ✅ | ✅ | same |
| **4** | **Browser control** — server→client `browser.control` frames: navigate / click / type / scroll / snapshot / extract via `chrome.scripting`; results correlated via `browser.control.result`; **gated by context-sharing consent + `allowBrowserControl` setting + per-action inline approval card** (session auto-approve option); restricted-URL + password-field guards | ✅ | — | outbound frame bridge |
| **6** | **Agent → extension file delivery** — server→client `file.delivery` events render a download card; saved via `chrome.downloads` (4 MiB cap, clipboard fallback) | ✅ | — | outbound frame bridge |
| **7** | **Docs** — README matrix + CHANGELOG | ✅ | | |

## Degradation contract

Every new RPC is **fail-closed**: on cores without WS→plugin dispatch the upload RPC rejects → the extension permanently falls back to full inline delivery (context is never lost), events are best-effort metadata, and control/file delivery simply never fire. This PR is safe to merge before the Hermes-core dispatcher exists.

## Security posture

- Context sharing stays **OFF by default for Hermes Cloud** (third-party endpoint); self-hosted remote dashboards default ON.
- Browser control is triple-gated: sharing consent + explicit `allowBrowserControl` setting + per-action approval in the panel.
- No new permissions: `downloads` and `scripting` were already in the manifest.
- Control refuses restricted schemes/URLs (`isRestrictedUrl`) and refuses to type into password fields.
- Events carry metadata only; uploads stay within the BCP 48k budget; file delivery caps at 4 MiB.

## Test results

`node --test tests/*.test.mjs` → **755 pass / 9 fail** — the 9 failures are pre-existing on `main` in this environment (verified identical set on a clean checkout): firefox-build, i18n-runtime, inline-draft-policy, site-adapters, context-menu-editor*, content-extraction-core, assistant-clipboard.

## Follow-ups (outside this repo)

- **Hermes core**: WS dispatcher → plugin `handle_ws_method` routing + outbound control/file frame bridge (spec'd in the plan doc).
- Companion-plugin control tools (`browser_navigate` etc.) land once the core bridge exists.
- Manual E2E: dev-load against a real Cloud agent, flip the toggle, verify `delivery: full` arrives agent-side.