### PR TITLE
fix: wire stop button to server-side run cancellation

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -3408,9 +3408,13 @@ els.composer.addEventListener('drop', (event) => {
 });
 els.stopRun.addEventListener('click', () => {
   if (activeRunId) {
-    client.fetch(`/v1/runs/${encodeURIComponent(activeRunId)}/stop`, { method: 'POST' }).catch((error) => {
-      els.composerStatus.textContent = `Stop failed: ${error?.message || 'Hermes runtime may still process the turn'}`;
-    });
+    client.fetch(`/v1/runs/${encodeURIComponent(activeRunId)}/stop`, { method: 'POST' })
+      .then((response) => {
+        if (!response.ok) throw new Error(`Stop request failed (HTTP ${response.status})`);
+      })
+      .catch((error) => {
+        els.composerStatus.textContent = `Stop failed: ${error?.message || 'Hermes runtime may still process the turn'}`;
+      });
   }
   activeAbortController?.abort();
 });

--- a/extension/app.js
+++ b/extension/app.js
@@ -3406,7 +3406,14 @@ els.composer.addEventListener('dragleave', (event) => {
 els.composer.addEventListener('drop', (event) => {
   handleComposerDrop(event).catch((error) => { els.composerStatus.textContent = `Drop failed: ${error?.message || String(error)}`; });
 });
-els.stopRun.addEventListener('click', () => activeAbortController?.abort());
+els.stopRun.addEventListener('click', () => {
+  if (activeRunId) {
+    client.fetch(`/v1/runs/${encodeURIComponent(activeRunId)}/stop`, { method: 'POST' }).catch((error) => {
+      els.composerStatus.textContent = `Stop failed: ${error?.message || 'Hermes runtime may still process the turn'}`;
+    });
+  }
+  activeAbortController?.abort();
+});
 els.attachButton.addEventListener('click', () => toggleAttachMenu());
 els.quickAttach.addEventListener('click', () => toggleAttachMenu(true));
 els.attachMenu.addEventListener('click', (event) => {

--- a/extension/content-extractor.js
+++ b/extension/content-extractor.js
@@ -1,5 +1,5 @@
 /* Generated from extension/lib/content-extraction-core.mjs, extension/lib/appearance-themes.mjs, extension/lib/site-adapters.mjs, extension/lib/inline-draft-policy.mjs. Do not edit directly. */
-/* extension/lib/content-extraction-core.mjs · SHA-256 33c00d3ec5789bc5 */
+/* extension/lib/content-extraction-core.mjs · SHA-256 519a8df0c4cf2def */
 (function hermesContentExtractorRuntime(hermesGlobal) {
   'use strict';
 
@@ -777,7 +777,7 @@ const CONTENT_EXTRACTION_API = Object.freeze({
   hermesGlobal.HermesContentExtractor = CONTENT_EXTRACTION_API;
 })(globalThis);
 
-/* extension/lib/appearance-themes.mjs · SHA-256 7f80382b764f41b8 */
+/* extension/lib/appearance-themes.mjs · SHA-256 667a76786cb4f8cd */
 (function hermesAppearanceRuntime(hermesGlobal) {
   'use strict';
 
@@ -921,7 +921,7 @@ const APPEARANCE_RUNTIME_API = Object.freeze({
   hermesGlobal.HermesAppearance = APPEARANCE_RUNTIME_API;
 })(globalThis);
 
-/* extension/lib/site-adapters.mjs · SHA-256 a311d362efb010dc */
+/* extension/lib/site-adapters.mjs · SHA-256 39cf88ea0dba5b14 */
 (function hermesSiteAdapterRuntime(hermesGlobal) {
   'use strict';
 
@@ -1638,7 +1638,7 @@ const SITE_ADAPTER_API = Object.freeze({
   hermesGlobal.HermesSiteAdapters = SITE_ADAPTER_API;
 })(globalThis);
 
-/* extension/lib/inline-draft-policy.mjs · SHA-256 29f83b2825b2a59a */
+/* extension/lib/inline-draft-policy.mjs · SHA-256 c1ed2d55c6be7883 */
 (function hermesInlineDraftRuntime(hermesGlobal) {
   'use strict';
 

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -2303,9 +2303,13 @@ async function stopCurrentTurn() {
   if (!sending) return;
   setStatus('warn', 'Stopping Hermes', activeRunId ? `Interrupt requested for ${activeRunId}` : 'Closing the active browser stream');
   if (activeRunId && !isRemoteWsMode()) {
-    apiFetch(`/v1/runs/${encodeURIComponent(activeRunId)}/stop`, { method: 'POST' }).catch((error) => {
-      setStatus('err', 'Stop request failed', error?.message || 'Hermes runtime may still process the turn');
-    });
+    apiFetch(`/v1/runs/${encodeURIComponent(activeRunId)}/stop`, { method: 'POST' })
+      .then((response) => {
+        if (!response.ok) throw new Error(`Stop request failed (HTTP ${response.status})`);
+      })
+      .catch((error) => {
+        setStatus('err', 'Stop request failed', error?.message || 'Hermes runtime may still process the turn');
+      });
   }
   activeAbortController?.abort();
 }

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -2303,7 +2303,9 @@ async function stopCurrentTurn() {
   if (!sending) return;
   setStatus('warn', 'Stopping Hermes', activeRunId ? `Interrupt requested for ${activeRunId}` : 'Closing the active browser stream');
   if (activeRunId && !isRemoteWsMode()) {
-    apiFetch(`/v1/runs/${encodeURIComponent(activeRunId)}/stop`, { method: 'POST' }).catch(() => {});
+    apiFetch(`/v1/runs/${encodeURIComponent(activeRunId)}/stop`, { method: 'POST' }).catch((error) => {
+      setStatus('err', 'Stop request failed', error?.message || 'Hermes runtime may still process the turn');
+    });
   }
   activeAbortController?.abort();
 }
@@ -6299,7 +6301,9 @@ function showSessionOwnershipNotice(session = {}, userText = '', turnAttachments
     fromComposer: String(userText || '').trim() === els.input.value.trim(),
   };
   els.sessionOwnershipTitle.textContent = `${sourceLabel} session selected`;
-  els.sessionOwnershipDetail.textContent = `This chat belongs to ${sourceLabel}. Start a Browser chat to keep the turn in Browser history, or continue here intentionally.`;
+  const messageCount = Number(session.messageCount || 0);
+  const largeWarning = messageCount > 100 ? ` This session has ${messageCount} messages. Two surfaces on one session can desync.` : '';
+  els.sessionOwnershipDetail.textContent = `This chat belongs to ${sourceLabel}. Two surfaces on one session can overwrite each other.${largeWarning} Start a Browser chat to keep the turn in Browser history, or continue here intentionally.`;
   const continueButton = els.sessionOwnershipNotice.querySelector('[data-session-ownership-action="continue"]');
   if (continueButton) continueButton.textContent = `Continue in ${sourceLabel}`;
   els.sessionOwnershipNotice.hidden = false;

--- a/tests/stop-cancellation.test.mjs
+++ b/tests/stop-cancellation.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const root = path.resolve(import.meta.dirname, '..');
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+
+test('Hermes Web stop click cancels the runtime run once and always aborts the local stream', () => {
+  const js = read('extension/app.js');
+  const start = js.indexOf('els.stopRun.addEventListener');
+  const end = js.indexOf('els.attachButton.addEventListener', start);
+  assert.ok(start >= 0 && end > start, 'expected the stopRun click handler in app.js');
+  const handler = js.slice(start, end);
+
+  assert.ok(handler.indexOf('if (activeRunId) {') < handler.indexOf('client.fetch'), 'the stop request must be guarded by an active run');
+  assert.equal((handler.match(/\/v1\/runs\/\$\{encodeURIComponent\(activeRunId\)\}\/stop/g) || []).length, 1, 'the stop endpoint must be posted exactly once');
+  assert.match(handler, /client\.fetch\(`\/v1\/runs\/\$\{encodeURIComponent\(activeRunId\)\}\/stop`, \{ method: 'POST' \}\)/);
+  assert.match(handler, /\.then\(\(response\)\s*=>\s*\{[\s\S]*?if\s*\(!response\.ok\)\s*throw/);
+  assert.match(handler, /\.catch\(\(error\)\s*=>\s*\{[\s\S]*?els\.composerStatus\.textContent\s*=\s*`Stop failed:/);
+  assert.match(handler, /\n {2}\}\n {2}activeAbortController\?\.abort\(\);/);
+});
+
+test('side panel stop cancels the run once, only while sending, and surfaces stop failures', () => {
+  const js = read('extension/sidepanel.js');
+  const fn = js.match(/async function stopCurrentTurn\(\)\s*\{([\s\S]*?)\n\}/)?.[1] || '';
+  assert.ok(fn, 'expected stopCurrentTurn in sidepanel.js');
+
+  assert.match(fn, /if\s*\(!sending\)\s*return;/);
+  assert.ok(fn.indexOf('if (activeRunId && !isRemoteWsMode()) {') < fn.indexOf('apiFetch'), 'the stop request must be guarded by an active local run');
+  assert.equal((fn.match(/\/v1\/runs\/\$\{encodeURIComponent\(activeRunId\)\}\/stop/g) || []).length, 1, 'the stop endpoint must be posted exactly once');
+  assert.match(fn, /apiFetch\(`\/v1\/runs\/\$\{encodeURIComponent\(activeRunId\)\}\/stop`, \{ method: 'POST' \}\)/);
+  assert.match(fn, /\.then\(\(response\)\s*=>\s*\{[\s\S]*?if\s*\(!response\.ok\)\s*throw/);
+  assert.match(fn, /\.catch\(\(error\)\s*=>\s*\{[\s\S]*?setStatus\('err',\s*'Stop request failed'/);
+  assert.match(fn, /\n {2}\}\s*activeAbortController\?\.abort\(\);/);
+});


### PR DESCRIPTION
## What this fixes

Fixes #69: the ghost loop where the agent keeps running after you click Stop in a shared session.

## Changes

1. **app.js (Hermes Web):** The stop button now calls `POST /v1/runs/{runId}/stop` on the Hermes runtime. Before this, the full-tab view only aborted the local browser stream — the runtime kept processing the turn with no UI. The side panel already made this call, but Hermes Web never did.

2. **sidepanel.js:** When the stop request fails, the status bar now shows the error. Before, errors were silently swallowed by `.catch(() => {})`, so the user never knew the stop command did not reach the runtime.

3. **sidepanel.js:** The "foreign session" dialog now warns about desync risk. Two surfaces writing to one session can overwrite each other. When the session has more than 100 messages, the dialog includes the message count as a warning.

## Verification

- `npm run check:js` — pass (all files syntax-checked)
- `npm run check:manifest` — pass
- `npm run lint` — pass (0 errors, pre-existing warnings only)
- `npm test` — 917 pass, 7 fail (pre-existing ENOENT path-encoding issue, not related to changes)

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke