### PR TITLE
fix: scroll prompt caret into view when commands menu opens; warn on large shared sessions

### DIFF
--- a/extension/lib/session-ownership.mjs
+++ b/extension/lib/session-ownership.mjs
@@ -80,11 +80,15 @@ export function sessionOwnershipNotice({ session = {}, expectedSource = '' } = {
   const newChatLabel = normalized(expectedSource) === SESSION_SURFACE_SOURCES.FULL_TAB
     ? 'New Hermes Web chat'
     : 'New Browser chat';
+  const largeSession = count !== null && count > 100;
+  const detail = largeSession
+    ? `${countDetail} Large shared sessions can desync: Stop in one surface may not reach the other, causing the agent to keep running invisibly. Start a new chat to avoid ghost loops.`
+    : `${countDetail} Two Browser surfaces writing the same session can overwrite or reorder transcript updates. Start a new chat, or continue here intentionally.`;
   return Object.freeze({
     sourceLabel,
     messageCount: count,
     title: `${sourceLabel} session selected`,
-    detail: `${countDetail} Two Browser surfaces writing the same session can overwrite or reorder transcript updates. Start a new chat, or continue here intentionally.`,
+    detail,
     newChatLabel,
     continueLabel: `Continue in ${sourceLabel}`,
   });

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -5657,6 +5657,17 @@ function setQuickCommandMenuOpen(open) {
   els.quickMoreMenu.hidden = !open;
   els.commandMenuButton?.setAttribute('aria-expanded', String(Boolean(open)));
   if (!open) clearQuickCommandDetail();
+  else scrollInputToCaret();
+}
+
+function scrollInputToCaret() {
+  const input = els.input;
+  if (!input || !input.setSelectionRange) return;
+  requestAnimationFrame(() => {
+    const pos = input.selectionStart || input.value.length;
+    input.setSelectionRange(pos, pos);
+    input.scrollTop = input.scrollHeight;
+  });
 }
 
 function clearQuickCommandDetail() {


### PR DESCRIPTION
## What this fixes\n\nTwo open issues:\n\n### #73 — /commands menu hides long prompt text\n\nThe quick-more-menu floats absolutely over the textarea. When a prompt spans several lines, the menu covers the caret and the user has to scroll to see what they are typing.\n\nFix: scrollInputToCaret() now runs when the menu opens — it sets the caret position and scrolls the textarea so the active line stays visible.\n\n### #69 — Ghost loop on shared sessions\n\nThe session ownership notice warned generically about two surfaces writing one session. For large sessions (100+ messages), it now explicitly calls out the ghost-loop/desync risk and steers users toward a new chat.\n\n## Changes\n\n- extension/sidepanel.js — setQuickCommandMenuOpen() calls scrollInputToCaret() on open; new scrollInputToCaret() helper\n- extension/lib/session-ownership.mjs — large-session detail text warns about ghost loops\n\n## Verification\n\n- npm run check:js — pass\n- npm run build — pass (self-contained check passed, dist built)\n- npx eslint — 0 errors, 60 warnings (all pre-existing)