### PR TITLE
fix(turns): surface provider request rejections

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -121,7 +121,11 @@ import {
   mergeDelegationWatchStores,
 } from './lib/async-delegation.mjs';
 import { normalizeInlineDraftRoutePreference } from './lib/inline-draft-policy.mjs';
-import { sessionContextFailureRecovery } from './lib/turn-recovery.mjs';
+import {
+  hermesRequestError,
+  sessionContextFailureRecovery,
+  turnRequestFailureState,
+} from './lib/turn-recovery.mjs';
 import { buildDashboardWsUrl, buildSessionModelSwitchRequest, createGatewayClient, establishGatewaySession, normalizeGatewayHistoryMessages, runtimeModelFromSessionStatus, WS_EVENTS, WS_METHODS } from './lib/gateway-ws.mjs';
 import { isTrustedDashboardOrigin, mintWsTicket, originOf, ticketFailureHelp } from './lib/dashboard-bridge.mjs';
 import {
@@ -3632,7 +3636,11 @@ async function sendPrompt(text) {
         selected_skills: skillSelection.selectedSkills,
       }),
     });
-    if (!response.ok || !response.body) throw new Error(`Hermes stream failed (${response.status}): ${(await response.text()).slice(0, 500)}`);
+    if (!response.ok || !response.body) throw hermesRequestError({
+      status: response.status,
+      body: await response.text(),
+      operation: 'Hermes stream',
+    });
     const streamedAnswer = await readHermesSse(response, {
       signal: activeAbortController.signal,
       onAssistant: (content) => {
@@ -3699,6 +3707,21 @@ async function sendPrompt(text) {
       activeRunControl = markRunTerminal(activeRunControl, streamTerminalStatus || 'completed');
     }
   } catch (error) {
+    const requestFailure = turnRequestFailureState(error);
+    if (requestFailure?.gatewayStatus === 'connected') {
+      activeMessages = activeMessages.filter((message) => message !== assistant);
+      if (!els.prompt.value.trim()) els.prompt.value = text;
+      attachments = [...turnAttachments];
+      renderAttachments();
+      activeMessages = [...activeMessages, {
+        role: 'system',
+        content: `${requestFailure.title}: ${requestFailure.detail} Gateway remains connected; adjust the model option and resend the preserved draft.`,
+      }];
+      els.composerStatus.textContent = `${requestFailure.title}: ${requestFailure.detail}`;
+      renderConnectionTruth({ status: 'online' });
+      renderMessages(activeMessages);
+      return false;
+    }
     const contextRecovery = sessionContextFailureRecovery(error, gatewayCapabilities);
     if (!contextRecovery) throw error;
     contextRecoveryHandled = true;

--- a/extension/lib/turn-recovery.mjs
+++ b/extension/lib/turn-recovery.mjs
@@ -1,6 +1,10 @@
+import { redactSensitiveText } from './redaction.mjs';
+
 export function classifyTurnRecovery(error = {}) {
-  if (error?.requestAccepted || !error?.fallbackSafe) return 'recover';
-  return 'fallback';
+  if (error?.requestAccepted) return 'recover';
+  if (error?.fallbackSafe) return 'fallback';
+  if (error?.requestRejected) return 'reject';
+  return 'recover';
 }
 
 function recoveryErrorText(value = '') {
@@ -10,6 +14,48 @@ function recoveryErrorText(value = '') {
     return String(value?.error?.message || value?.error || value?.message || '');
   }
   return String(value || '');
+}
+
+function responseErrorDetail(body = '') {
+  const text = String(body || '').trim();
+  if (!text) return '';
+  try {
+    const payload = JSON.parse(text);
+    const detail = payload?.error?.message
+      || payload?.error
+      || payload?.detail
+      || payload?.message;
+    if (detail && typeof detail === 'object') return redactSensitiveText(JSON.stringify(detail)).slice(0, 900);
+    if (detail != null && String(detail).trim()) return redactSensitiveText(String(detail).replace(/\s+/g, ' ').trim()).slice(0, 900);
+  } catch {
+    // Non-JSON provider bodies still carry useful validation details.
+  }
+  return redactSensitiveText(text.replace(/\s+/g, ' ')).slice(0, 900);
+}
+
+export function hermesRequestError({ status = 0, body = '', operation = 'Hermes request' } = {}) {
+  const statusCode = Number.isFinite(Number(status)) ? Math.trunc(Number(status)) : 0;
+  const label = String(operation || 'Hermes request').trim() || 'Hermes request';
+  const detail = responseErrorDetail(body);
+  const error = new Error(`${label} failed${statusCode ? ` (${statusCode})` : ''}${detail ? `: ${detail}` : ''}`);
+  error.httpStatus = statusCode;
+  error.fallbackSafe = [404, 405, 501].includes(statusCode);
+  error.requestRejected = statusCode >= 400 && statusCode < 500;
+  return error;
+}
+
+export function turnRequestFailureState(error = {}) {
+  const status = Number(error?.httpStatus || 0);
+  if (!error?.requestRejected || error?.fallbackSafe || [401, 403].includes(status)) return null;
+  const detail = recoveryErrorText(error).replace(/^Error:\s*/, '').trim();
+  const modelOptionRejected = /reasoning[_ -]?effort|thinking.{0,60}(?:unsupported|must be one of)|unsupported.{0,60}reasoning/i.test(detail);
+  return {
+    kind: modelOptionRejected ? 'model-option-rejected' : 'request-rejected',
+    title: modelOptionRejected ? 'Model option rejected' : 'Hermes request rejected',
+    detail,
+    preserveDraft: true,
+    gatewayStatus: 'connected',
+  };
 }
 
 export function sessionContextFailureRecovery(error = {}, capabilities = {}) {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -198,7 +198,13 @@ import {
   isDelegationCompletionMarkerMessage,
   mergeDelegationWatchStores,
 } from './lib/async-delegation.mjs';
-import { classifyTurnRecovery, latestAssistantAfterUser, sessionContextFailureRecovery } from './lib/turn-recovery.mjs';
+import {
+  classifyTurnRecovery,
+  hermesRequestError,
+  latestAssistantAfterUser,
+  sessionContextFailureRecovery,
+  turnRequestFailureState,
+} from './lib/turn-recovery.mjs';
 import { createDiffusionCanvas, diffusionVariantForSeed } from './lib/diffusion-canvas.mjs';
 import { buildSupportDiagnostics } from './lib/support-diagnostics.mjs';
 import {
@@ -9205,9 +9211,11 @@ async function streamSessionChat(prompt, onDelta, onTool, { signal, attachments:
 
   if (!response.ok || !response.body) {
     const text = await response.text();
-    const error = new Error(`Hermes stream failed (${response.status}): ${text.slice(0, 900)}`);
-    error.fallbackSafe = [404, 405, 501].includes(response.status);
-    throw error;
+    throw hermesRequestError({
+      status: response.status,
+      body: text,
+      operation: 'Hermes stream',
+    });
   }
   try {
     return await readSseResponse(response, onDelta, onTool, { signal, onRun, onSteerQueued, onRuntime });
@@ -9245,9 +9253,11 @@ async function streamChatCompletions(prompt, onDelta, onTool, { signal, attachme
   }
   if (!response.ok || !response.body) {
     const text = await response.text();
-    const error = new Error(`Hermes chat-completions stream failed (${response.status}): ${text.slice(0, 900)}`);
-    error.fallbackSafe = [404, 405, 501].includes(response.status);
-    throw error;
+    throw hermesRequestError({
+      status: response.status,
+      body: text,
+      operation: 'Hermes chat-completions stream',
+    });
   }
   try {
     const result = await readSseResponse(response, onDelta, onTool, { signal, onRun });
@@ -9609,6 +9619,7 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
 
   let didSend = false;
   let streamTerminalStatus = '';
+  let streamView = null;
   try {
     const preparedAttachments = await saveImageAttachmentsForTurn(turnAttachments);
     if (typeof turnOptions.resolveUserText === 'function' && isRemoteWsMode()) {
@@ -9715,7 +9726,7 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
       { onOpen: (image) => openGeneratedImageLightbox(image) },
     );
     const { node } = addMessage('assistant', THINKING_PLACEHOLDER, { persist: false });
-    const streamView = createStreamingMessageUpdater(node);
+    streamView = createStreamingMessageUpdater(node);
     let answer = '';
     let liveText = '';
     try {
@@ -9762,7 +9773,10 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
         streamView.update(`Could not reach the Hermes dashboard.\n${streamError.message}`);
         throw streamError;
       } else {
-        if (classifyTurnRecovery(streamError) === 'fallback') {
+        const recoveryAction = classifyTurnRecovery(streamError);
+        if (recoveryAction === 'reject') {
+          throw streamError;
+        } else if (recoveryAction === 'fallback') {
           streamView.update(`Streaming failed, retrying non-streaming...\n${streamError.message}`);
           answer = await fallbackSessionChat(prompt, preparedAttachments, {
             onRuntime: (payload) => {
@@ -9846,6 +9860,21 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
       }
       if (error?.remoteDiagnostic && applyRemoteDiagnostic(error.remoteDiagnostic, { statusKind: 'error' })) {
         addMessage('system', `Hermes Browser Extension setup issue: ${error.remoteDiagnostic.detail} Open Settings → Support diagnostics → Copy Diagnostics and paste the redacted report if you need help.`);
+        return didSend;
+      }
+      const requestFailure = turnRequestFailureState(error);
+      if (requestFailure?.gatewayStatus === 'connected') {
+        if (!turnOptions.preserveComposer && !els.input.value.trim() && !attachments.length) {
+          els.input.value = userText;
+          attachments = [...turnAttachments];
+          renderAttachments();
+          renderSkillSuggestions();
+        }
+        streamView.update(`${requestFailure.title}\n${requestFailure.detail}`);
+        setStatus('error', requestFailure.title, `${requestFailure.detail} Gateway remains connected.`, {
+          translateTitle: false,
+          translateDetail: false,
+        });
         return didSend;
       }
       const diagnostic = classifyGatewayError(error);

--- a/tests/e2e-loaded-extension.mjs
+++ b/tests/e2e-loaded-extension.mjs
@@ -34,6 +34,7 @@ const INLINE_DELETE_ALL_SCREENSHOT = path.join(QA_DIR, `x-rich-delete-all${ASSIS
 const ASSIST_SETTINGS_SCREENSHOT = path.join(QA_DIR, `assist-settings${ASSIST_SCREENSHOT_SUFFIX}.png`);
 const ASSIST_RELEASED_GATEWAY_SCREENSHOT = path.join(QA_DIR, `assist-settings-released-gateway${ASSIST_SCREENSHOT_SUFFIX}.png`);
 const MAIN_MODEL_PICKER_SCREENSHOT = path.join(QA_DIR, `main-model-picker${ASSIST_SCREENSHOT_SUFFIX}.png`);
+const PROVIDER_REJECTION_PANEL_SCREENSHOT = path.join(QA_DIR, `provider-rejection-panel${ASSIST_SCREENSHOT_SUFFIX}.png`);
 const GPT56_CONTEXT_PICKER_SCREENSHOT = path.join(QA_DIR, `gpt56-context-picker${ASSIST_SCREENSHOT_SUFFIX}.png`);
 const READABILITY_PANEL_SCREENSHOT = path.join(QA_DIR, `readability-panel-320${ASSIST_SCREENSHOT_SUFFIX}.png`);
 const READABILITY_WEB_SCREENSHOT = path.join(QA_DIR, `readability-web-1024${ASSIST_SCREENSHOT_SUFFIX}.png`);
@@ -239,6 +240,7 @@ async function startMockHermes() {
   let fullTabDelegationSessionId = '';
   let fullTabDelegationCompletionAvailableAt = 0;
   let fullTabDelegationHistoryPolls = 0;
+  let nextChatStreamRejection = null;
   const server = createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     const body = await requestBody(req);
@@ -495,6 +497,12 @@ async function startMockHermes() {
     }
     if (/^\/api\/sessions\/[^/]+\/chat\/stream$/.test(url.pathname) && req.method === 'POST') {
       chatRequest = body;
+      if (nextChatStreamRejection) {
+        const rejection = nextChatStreamRejection;
+        nextChatStreamRejection = null;
+        json(res, rejection.status, { error: { message: rejection.message } });
+        return;
+      }
       const sessionId = decodeURIComponent(url.pathname.split('/')[3] || '');
       const message = String(body?.message || '');
       const delegated = message.includes(DELEGATION_PROMPT);
@@ -586,6 +594,9 @@ async function startMockHermes() {
     setAssistChatAcknowledgement: (mode = 'direct') => { assistChatAcknowledgement = mode; },
     setAssistCleanupStatus: (status = 204) => { assistCleanupStatus = Number(status); },
     setAssistSessionModelRouting: (enabled = true) => { assistSessionModelRouting = Boolean(enabled); },
+    rejectNextChatStream: ({ status = 400, message = 'Invalid request.' } = {}) => {
+      nextChatStreamRejection = { status: Number(status), message: String(message) };
+    },
     close: () => new Promise((resolve) => server.close(resolve)),
   };
 }
@@ -1125,6 +1136,36 @@ async function main() {
     assert.ok(envelope.source_receipt);
     assert.ok(mock.requests.some((request) => request.path === `/api/sessions/${storedAfterSend.hermesBrowserSettings.sessionId}/chat/stream` && request.method === 'POST'));
     assert.ok(mock.requests.filter((request) => request.path !== '/health' && request.path !== '/v1/health').every((request) => request.authorization === `Bearer ${TEST_TOKEN}`));
+
+    const rejectionPrompt = 'Verify unsupported reasoning option handling.';
+    const rejectionDetail = 'Invalid parameter: reasoning_effort must be one of low, medium, high.';
+    const rejectionStreamsBefore = mock.requests.filter((request) => /\/chat\/stream$/.test(request.path) && request.method === 'POST').length;
+    const fallbackChatsBefore = mock.requests.filter((request) => /\/chat$/.test(request.path) && request.method === 'POST').length;
+    mock.rejectNextChatStream({ status: 400, message: rejectionDetail });
+    await panel.evaluate(`(() => {
+      const input = document.querySelector('#promptInput');
+      input.value = ${JSON.stringify(rejectionPrompt)};
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      document.querySelector('#composer').requestSubmit();
+      return true;
+    })()`);
+    const rejectionState = await waitFor(() => panel.evaluate(`(() => {
+      const messages = Array.from(document.querySelectorAll('.message-content')).map((node) => node.textContent).join('\\n');
+      const input = document.querySelector('#promptInput');
+      const title = document.querySelector('#activeTitle')?.textContent || '';
+      const detail = document.querySelector('#activeUrl')?.textContent || '';
+      const connection = document.querySelector('#connectionPill')?.getAttribute('aria-label') || '';
+      if (input?.value !== ${JSON.stringify(rejectionPrompt)} || title !== 'Model option rejected' || !messages.includes(${JSON.stringify(rejectionDetail)})) return null;
+      return { messages, detail, connection };
+    })()`));
+    assert.match(rejectionState.detail, /Gateway remains connected\./);
+    assert.equal(rejectionState.connection, 'Hermes connected');
+    assert.doesNotMatch(rejectionState.messages, /Hermes API unavailable/);
+    const rejectionStreamsAfter = mock.requests.filter((request) => /\/chat\/stream$/.test(request.path) && request.method === 'POST').length;
+    const fallbackChatsAfter = mock.requests.filter((request) => /\/chat$/.test(request.path) && request.method === 'POST').length;
+    assert.equal(rejectionStreamsAfter, rejectionStreamsBefore + 1, 'Provider rejection must not replay the stream.');
+    assert.equal(fallbackChatsAfter, fallbackChatsBefore, 'Provider rejection must not fall back to non-streaming replay.');
+    await saveScreenshot(panel, PROVIDER_REJECTION_PANEL_SCREENSHOT);
 
     const delegationStreamsBefore = mock.requests.filter((request) => /\/chat\/stream$/.test(request.path) && request.method === 'POST').length;
     await panel.evaluate(`(() => {

--- a/tests/turn-recovery.test.mjs
+++ b/tests/turn-recovery.test.mjs
@@ -6,7 +6,9 @@ import * as turnRecovery from '../extension/lib/turn-recovery.mjs';
 
 const {
   classifyTurnRecovery,
+  hermesRequestError,
   latestAssistantAfterUser,
+  turnRequestFailureState,
 } = turnRecovery;
 
 const sidepanelSource = readFileSync(new URL('../extension/sidepanel.js', import.meta.url), 'utf8');
@@ -20,6 +22,57 @@ test('accepted stream failures recover instead of retrying the turn', () => {
 test('explicitly rejected stream routes may use the non-stream fallback', () => {
   assert.equal(classifyTurnRecovery({ fallbackSafe: true }), 'fallback');
   assert.equal(classifyTurnRecovery({ fallbackSafe: true, requestAccepted: true }), 'recover');
+});
+
+test('provider validation failures are rejected requests instead of accepted-turn recovery', () => {
+  const error = hermesRequestError({
+    status: 400,
+    operation: 'Hermes stream',
+    body: JSON.stringify({
+      error: {
+        message: 'reasoning_effort must be one of: no_think, low, high',
+      },
+    }),
+  });
+
+  assert.equal(error.message, 'Hermes stream failed (400): reasoning_effort must be one of: no_think, low, high');
+  assert.equal(error.httpStatus, 400);
+  assert.equal(error.requestRejected, true);
+  assert.equal(error.fallbackSafe, false);
+  assert.equal(classifyTurnRecovery(error), 'reject');
+});
+
+test('provider rejection details are redacted before reaching either Browser surface', () => {
+  const error = hermesRequestError({
+    status: 400,
+    body: JSON.stringify({ error: { message: 'reasoning_effort is invalid; Bearer private-value token=private-value' } }),
+  });
+
+  assert.match(error.message, /reasoning_effort is invalid/);
+  assert.match(error.message, /REDACTED/);
+  assert.doesNotMatch(error.message, /private-value/);
+});
+
+test('provider option rejection keeps gateway health separate and preserves the draft', () => {
+  const state = turnRequestFailureState(hermesRequestError({
+    status: 400,
+    body: '{"error":"reasoning_effort must be one of: no_think, low, high"}',
+  }));
+
+  assert.deepEqual(state, {
+    kind: 'model-option-rejected',
+    title: 'Model option rejected',
+    detail: 'Hermes request failed (400): reasoning_effort must be one of: no_think, low, high',
+    preserveDraft: true,
+    gatewayStatus: 'connected',
+  });
+});
+
+test('authentication rejection stays on the existing gateway-auth diagnostic path', () => {
+  const error = hermesRequestError({ status: 401, body: '{"error":"Unauthorized"}' });
+
+  assert.equal(classifyTurnRecovery(error), 'reject');
+  assert.equal(turnRequestFailureState(error), null);
 });
 
 test('recovery selects the assistant after the latest matching user turn', () => {
@@ -83,4 +136,16 @@ test('Hermes Web preserves the failed draft and uses the same acknowledged conte
   assert.match(appSource, /sessionContextFailureRecovery\(error, gatewayCapabilities\)/);
   assert.match(appSource, /await compactActiveSessionContext\(\{[\s\S]{0,160}automaticRecovery:\s*true/);
   assert.match(appSource, /retryTurn/);
+});
+
+test('both Browser surfaces preserve provider-rejected drafts without marking Hermes unreachable', () => {
+  assert.match(sidepanelSource, /hermesRequestError\(\{[\s\S]{0,180}status:\s*response\.status[\s\S]{0,180}body:\s*text/);
+  const sidepanelRejectionStart = sidepanelSource.lastIndexOf('const requestFailure = turnRequestFailureState(error)');
+  const sidepanelRejectionBranch = sidepanelSource.slice(sidepanelRejectionStart, sidepanelSource.indexOf('const diagnostic = classifyGatewayError(error)', sidepanelRejectionStart));
+  assert.match(sidepanelRejectionBranch, /Gateway remains connected/);
+  assert.match(sidepanelRejectionBranch, /streamView\.update/);
+  assert.doesNotMatch(sidepanelRejectionBranch, /addMessage\('system'/);
+  assert.match(sidepanelSource, /classifyTurnRecovery\(streamError\)[\s\S]{0,120}=== 'reject'/);
+  assert.match(appSource, /hermesRequestError\(\{[\s\S]{0,180}status:\s*response\.status[\s\S]{0,180}body:\s*await response\.text\(\)/);
+  assert.match(appSource, /turnRequestFailureState\(error\)[\s\S]{0,700}renderConnectionTruth\(\{\s*status:\s*'online'\s*\}\)/);
 });


### PR DESCRIPTION
## Summary

- classify definitive HTTP provider/request failures separately from accepted or ambiguous stream failures
- surface the real redacted provider message, preserve the rejected draft, and keep healthy gateway state connected in the side panel and Hermes Web
- prevent provider validation failures from entering accepted-turn recovery or non-stream replay
- add focused RED contracts plus a real loaded-extension regression for the reported `reasoning_effort` 400 path

## Verification

- `npm run test` — 1,270 passed, 0 failed
- `npm run lint` — 0 errors (existing warning baseline remains)
- `npm run build` — passed
- loaded-extension CDP E2E — PASS against an authenticated mock Hermes gateway; one rejected stream, zero replay/fallback requests, draft restored, gateway connected
- GitNexus `detect-changes` — 5 files, 28 affected flows, critical shared-turn surface covered by full suite and loaded-extension E2E

## Baseline note

`npm audit` remains red on both `main` and this branch for the existing `web-ext → addons-linter → image-size` advisory chain. This PR makes no dependency changes; the offered remediation is a breaking forced downgrade.

Closes #79