### PR TITLE
fix(turns): harden provider rejection transports

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -122,6 +122,7 @@ import {
 } from './lib/async-delegation.mjs';
 import { normalizeInlineDraftRoutePreference } from './lib/inline-draft-policy.mjs';
 import {
+  hermesGatewayTurnError,
   hermesRequestError,
   sessionContextFailureRecovery,
   turnRequestFailureState,
@@ -727,6 +728,11 @@ async function streamDashboardPrompt(prompt, { signal, onDelta, onTool, onRun } 
     }));
     offs.push(connection.client.on(WS_EVENTS.messageComplete, (event) => {
       if (!forThisSession(event)) return;
+      const completionError = hermesGatewayTurnError({ payload: event.payload });
+      if (completionError) {
+        finish(reject, completionError);
+        return;
+      }
       finalText = event.payload?.text || finalText;
       onDelta?.(finalText);
       finish(resolve, finalText);
@@ -743,7 +749,7 @@ async function streamDashboardPrompt(prompt, { signal, onDelta, onTool, onRun } 
     }));
     offs.push(connection.client.on(WS_EVENTS.error, (event) => {
       if (!forThisSession(event)) return;
-      finish(reject, new Error(event.payload?.message || 'Dashboard stream error'));
+      finish(reject, hermesGatewayTurnError({ payload: event.payload }) || new Error('Dashboard stream error'));
     }));
     offs.push(connection.client.on('close', () => finish(reject, new Error('Dashboard connection closed mid-turn.'))));
     connection.client.request(WS_METHODS.promptSubmit, { session_id: sessionId, text: prompt }).catch((error) => finish(reject, error));

--- a/extension/lib/turn-recovery.mjs
+++ b/extension/lib/turn-recovery.mjs
@@ -3,7 +3,7 @@ import { redactSensitiveText } from './redaction.mjs';
 export function classifyTurnRecovery(error = {}) {
   if (error?.requestAccepted) return 'recover';
   if (error?.fallbackSafe) return 'fallback';
-  if (error?.requestRejected) return 'reject';
+  if (error?.requestRejected || error?.turnFailureLayer === 'provider') return 'reject';
   return 'recover';
 }
 
@@ -33,6 +33,19 @@ function responseErrorDetail(body = '') {
   return redactSensitiveText(text.replace(/\s+/g, ' ')).slice(0, 900);
 }
 
+function modelOptionRejectionText(value = '') {
+  return /reasoning[_ -]?effort|thinking.{0,60}(?:unsupported|must be one of)|unsupported.{0,60}reasoning/i.test(String(value || ''));
+}
+
+function normalizedErrorSurface(value = {}) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const layer = String(value.layer || '').trim().toLowerCase().slice(0, 40);
+  const code = String(value.code || '').trim().slice(0, 120);
+  const retryable = typeof value.retryable === 'boolean' ? value.retryable : null;
+  if (!layer && !code && retryable == null) return null;
+  return { layer, code, retryable };
+}
+
 export function hermesRequestError({ status = 0, body = '', operation = 'Hermes request' } = {}) {
   const statusCode = Number.isFinite(Number(status)) ? Math.trunc(Number(status)) : 0;
   const label = String(operation || 'Hermes request').trim() || 'Hermes request';
@@ -44,14 +57,42 @@ export function hermesRequestError({ status = 0, body = '', operation = 'Hermes 
   return error;
 }
 
+export function hermesGatewayTurnError({ payload = {}, operation = 'Hermes dashboard stream' } = {}) {
+  const record = payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : {};
+  const surface = normalizedErrorSurface(record.error_surface || record.errorSurface);
+  const statusLabel = String(record.status || '').trim().toLowerCase();
+  const detail = record.error ?? record.message ?? '';
+  if (statusLabel !== 'error' && !String(detail || '').trim() && !surface) return null;
+
+  const rawStatus = record.http_status ?? record.status_code ?? record.httpStatus ?? 0;
+  const error = hermesRequestError({
+    status: rawStatus,
+    body: JSON.stringify({ error: detail || 'Dashboard turn failed.' }),
+    operation,
+  });
+  error.errorSurface = surface;
+  error.turnFailureLayer = surface?.layer || '';
+
+  if (surface?.layer === 'provider' || modelOptionRejectionText(error.message)) {
+    error.turnFailureLayer = 'provider';
+    error.requestRejected = true;
+    error.fallbackSafe = false;
+  }
+  return error;
+}
+
 export function turnRequestFailureState(error = {}) {
   const status = Number(error?.httpStatus || 0);
-  if (!error?.requestRejected || error?.fallbackSafe || [401, 403].includes(status)) return null;
+  const providerFailure = error?.turnFailureLayer === 'provider';
+  if ((!error?.requestRejected && !providerFailure) || error?.fallbackSafe || [401, 403].includes(status)) return null;
   const detail = recoveryErrorText(error).replace(/^Error:\s*/, '').trim();
-  const modelOptionRejected = /reasoning[_ -]?effort|thinking.{0,60}(?:unsupported|must be one of)|unsupported.{0,60}reasoning/i.test(detail);
+  const modelOptionRejected = modelOptionRejectionText(detail);
+  const providerTitle = error?.errorSurface?.retryable === false
+    ? 'Provider request rejected'
+    : 'Provider turn failed';
   return {
-    kind: modelOptionRejected ? 'model-option-rejected' : 'request-rejected',
-    title: modelOptionRejected ? 'Model option rejected' : 'Hermes request rejected',
+    kind: modelOptionRejected ? 'model-option-rejected' : providerFailure ? 'provider-turn-failed' : 'request-rejected',
+    title: modelOptionRejected ? 'Model option rejected' : providerFailure ? providerTitle : 'Hermes request rejected',
     detail,
     preserveDraft: true,
     gatewayStatus: 'connected',

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -200,6 +200,7 @@ import {
 } from './lib/async-delegation.mjs';
 import {
   classifyTurnRecovery,
+  hermesGatewayTurnError,
   hermesRequestError,
   latestAssistantAfterUser,
   sessionContextFailureRecovery,
@@ -9155,6 +9156,11 @@ async function streamRemoteWsChat(prompt, onDelta, onTool, { signal, onRun } = {
     }));
     offs.push(client.on(WS_EVENTS.messageComplete, (event) => {
       if (!forThisSession(event)) return;
+      const completionError = hermesGatewayTurnError({ payload: event.payload });
+      if (completionError) {
+        finish(reject, completionError);
+        return;
+      }
       finalText = event.payload?.text || finalText;
       onDelta(finalText);
       finish(resolve, finalText);
@@ -9171,7 +9177,7 @@ async function streamRemoteWsChat(prompt, onDelta, onTool, { signal, onRun } = {
     }));
     offs.push(client.on(WS_EVENTS.error, (event) => {
       if (!forThisSession(event)) return;
-      finish(reject, new Error(event.payload?.message || 'Dashboard stream error'));
+      finish(reject, hermesGatewayTurnError({ payload: event.payload }) || new Error('Dashboard stream error'));
     }));
     offs.push(client.on('close', () => finish(reject, new Error('Dashboard connection closed mid-turn.'))));
 
@@ -9530,7 +9536,11 @@ async function fallbackSessionChat(prompt, turnAttachments = attachments, { onRu
         }),
   });
   const payload = await readJsonResponse(response);
-  if (!response.ok) throw new Error(payload?.error?.message || payload?.error || `Hermes request failed (${response.status})`);
+  if (!response.ok) throw hermesRequestError({
+    status: response.status,
+    body: JSON.stringify(payload),
+    operation: 'Hermes request',
+  });
   onRuntime?.(payload);
   await captureDelegationDispatchesFromCurrentRestHistory();
   return extractAssistantText(payload);
@@ -9555,7 +9565,11 @@ async function fallbackChatCompletions(prompt, turnAttachments = attachments) {
     }),
   });
   const payload = await readJsonResponse(response);
-  if (!response.ok) throw new Error(payload?.error?.message || payload?.error || `Hermes request failed (${response.status})`);
+  if (!response.ok) throw hermesRequestError({
+    status: response.status,
+    body: JSON.stringify(payload),
+    operation: 'Hermes chat-completions request',
+  });
   await captureDelegationDispatchesFromCurrentRestHistory();
   return extractAssistantText(payload);
 }
@@ -9767,14 +9781,14 @@ async function askHermes(userText, turnAttachments = [...attachments], turnOptio
         throw streamError;
       } else if (sessionContextFailureRecovery(streamError, gatewayCapabilities)) {
         throw streamError;
-      } else if (isRemoteWsMode()) {
-        // No REST fallback in remote-dashboard mode — the api_server surface is
-        // not reachable cross-origin. Surface the WS/ticket error directly.
-        streamView.update(`Could not reach the Hermes dashboard.\n${streamError.message}`);
-        throw streamError;
       } else {
         const recoveryAction = classifyTurnRecovery(streamError);
         if (recoveryAction === 'reject') {
+          throw streamError;
+        } else if (isRemoteWsMode()) {
+          // No REST fallback in remote-dashboard mode — the api_server surface is
+          // not reachable cross-origin. Surface genuine WS/ticket errors directly.
+          streamView.update(`Could not reach the Hermes dashboard.\n${streamError.message}`);
           throw streamError;
         } else if (recoveryAction === 'fallback') {
           streamView.update(`Streaming failed, retrying non-streaming...\n${streamError.message}`);

--- a/tests/e2e-loaded-extension.mjs
+++ b/tests/e2e-loaded-extension.mjs
@@ -241,6 +241,7 @@ async function startMockHermes() {
   let fullTabDelegationCompletionAvailableAt = 0;
   let fullTabDelegationHistoryPolls = 0;
   let nextChatStreamRejection = null;
+  let nextChatFallbackRejection = null;
   const server = createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1');
     const body = await requestBody(req);
@@ -553,6 +554,12 @@ async function startMockHermes() {
     }
     if (/^\/api\/sessions\/[^/]+\/chat$/.test(url.pathname) && req.method === 'POST') {
       chatRequest = body;
+      if (nextChatFallbackRejection) {
+        const rejection = nextChatFallbackRejection;
+        nextChatFallbackRejection = null;
+        json(res, rejection.status, { error: { message: rejection.message } });
+        return;
+      }
       const payload = {
         content: INLINE_REPLY,
         message: { role: 'assistant', content: INLINE_REPLY },
@@ -596,6 +603,9 @@ async function startMockHermes() {
     setAssistSessionModelRouting: (enabled = true) => { assistSessionModelRouting = Boolean(enabled); },
     rejectNextChatStream: ({ status = 400, message = 'Invalid request.' } = {}) => {
       nextChatStreamRejection = { status: Number(status), message: String(message) };
+    },
+    rejectNextChatFallback: ({ status = 400, message = 'Invalid request.' } = {}) => {
+      nextChatFallbackRejection = { status: Number(status), message: String(message) };
     },
     close: () => new Promise((resolve) => server.close(resolve)),
   };
@@ -1166,6 +1176,36 @@ async function main() {
     assert.equal(rejectionStreamsAfter, rejectionStreamsBefore + 1, 'Provider rejection must not replay the stream.');
     assert.equal(fallbackChatsAfter, fallbackChatsBefore, 'Provider rejection must not fall back to non-streaming replay.');
     await saveScreenshot(panel, PROVIDER_REJECTION_PANEL_SCREENSHOT);
+
+    const fallbackRejectionPrompt = 'Verify fallback provider rejection handling.';
+    const fallbackRejectionDetail = 'Unsupported parameter: reasoning_effort must be one of low, medium, high.';
+    const fallbackRejectionStreamsBefore = mock.requests.filter((request) => /\/chat\/stream$/.test(request.path) && request.method === 'POST').length;
+    const fallbackRejectionChatsBefore = mock.requests.filter((request) => /\/chat$/.test(request.path) && request.method === 'POST').length;
+    mock.rejectNextChatStream({ status: 404, message: 'Streaming route unavailable.' });
+    mock.rejectNextChatFallback({ status: 400, message: fallbackRejectionDetail });
+    await panel.evaluate(`(() => {
+      const input = document.querySelector('#promptInput');
+      input.value = ${JSON.stringify(fallbackRejectionPrompt)};
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      document.querySelector('#composer').requestSubmit();
+      return true;
+    })()`);
+    const fallbackRejectionState = await waitFor(() => panel.evaluate(`(() => {
+      const messages = Array.from(document.querySelectorAll('.message-content')).map((node) => node.textContent).join('\\n');
+      const input = document.querySelector('#promptInput');
+      const title = document.querySelector('#activeTitle')?.textContent || '';
+      const detail = document.querySelector('#activeUrl')?.textContent || '';
+      const connection = document.querySelector('#connectionPill')?.getAttribute('aria-label') || '';
+      if (input?.value !== ${JSON.stringify(fallbackRejectionPrompt)} || title !== 'Model option rejected' || !messages.includes(${JSON.stringify(fallbackRejectionDetail)})) return null;
+      return { messages, detail, connection };
+    })()`));
+    assert.match(fallbackRejectionState.detail, /Gateway remains connected\./);
+    assert.equal(fallbackRejectionState.connection, 'Hermes connected');
+    assert.doesNotMatch(fallbackRejectionState.messages, /Hermes API unavailable/);
+    const fallbackRejectionStreamsAfter = mock.requests.filter((request) => /\/chat\/stream$/.test(request.path) && request.method === 'POST').length;
+    const fallbackRejectionChatsAfter = mock.requests.filter((request) => /\/chat$/.test(request.path) && request.method === 'POST').length;
+    assert.equal(fallbackRejectionStreamsAfter, fallbackRejectionStreamsBefore + 1, 'Fallback rejection must not replay the stream.');
+    assert.equal(fallbackRejectionChatsAfter, fallbackRejectionChatsBefore + 1, 'Fallback rejection must make exactly one bounded non-streaming request.');
 
     const delegationStreamsBefore = mock.requests.filter((request) => /\/chat\/stream$/.test(request.path) && request.method === 'POST').length;
     await panel.evaluate(`(() => {
@@ -2834,7 +2874,12 @@ async function main() {
       assert.equal(request.body.model, 'e2e/test-model');
       assert.equal(request.body.provider, 'e2e');
     }
-    const assistChats = mock.requests.filter((request) => request.method === 'POST' && /^\/api\/sessions\/[^/]+\/chat$/.test(request.path) && request.body?.model === 'e2e/test-model');
+    const assistChats = mock.requests.filter((request) => (
+      request.method === 'POST'
+      && /^\/api\/sessions\/[^/]+\/chat$/.test(request.path)
+      && request.body?.model === 'e2e/test-model'
+      && Object.hasOwn(request.body || {}, 'reasoning_effort')
+    ));
     assert.ok(assistChats.length >= 2);
     assert.ok(assistChats.every((request) => request.body.fast === false && request.body.model_options?.fast === false && request.body.reasoning_effort === 'low'));
     assert.equal(mock.requests.filter((request) => request.method === 'DELETE' && /^\/api\/sessions\//.test(request.path)).length, 1);

--- a/tests/turn-recovery.test.mjs
+++ b/tests/turn-recovery.test.mjs
@@ -6,6 +6,7 @@ import * as turnRecovery from '../extension/lib/turn-recovery.mjs';
 
 const {
   classifyTurnRecovery,
+  hermesGatewayTurnError,
   hermesRequestError,
   latestAssistantAfterUser,
   turnRequestFailureState,
@@ -73,6 +74,54 @@ test('authentication rejection stays on the existing gateway-auth diagnostic pat
 
   assert.equal(classifyTurnRecovery(error), 'reject');
   assert.equal(turnRequestFailureState(error), null);
+});
+
+test('dashboard provider terminal events stay separate from gateway connectivity', () => {
+  const error = hermesGatewayTurnError({
+    operation: 'Hermes dashboard stream',
+    payload: {
+      status: 'error',
+      error: 'Invalid parameter: reasoning_effort must be one of low, medium, high.',
+      error_surface: {
+        layer: 'provider',
+        code: 'format_error',
+        retryable: false,
+      },
+    },
+  });
+
+  assert.ok(error instanceof Error);
+  assert.equal(error.turnFailureLayer, 'provider');
+  assert.equal(classifyTurnRecovery(error), 'reject');
+  assert.deepEqual(turnRequestFailureState(error), {
+    kind: 'model-option-rejected',
+    title: 'Model option rejected',
+    detail: 'Hermes dashboard stream failed: Invalid parameter: reasoning_effort must be one of low, medium, high.',
+    preserveDraft: true,
+    gatewayStatus: 'connected',
+  });
+});
+
+test('dashboard completion shaping ignores success and preserves real gateway failures', () => {
+  assert.equal(hermesGatewayTurnError({ payload: { status: 'completed', text: 'Done.' } }), null);
+
+  const gatewayError = hermesGatewayTurnError({
+    payload: {
+      status: 'error',
+      error: 'Dashboard worker crashed.',
+      error_surface: { layer: 'gateway', code: 'RuntimeError', retryable: true },
+    },
+  });
+  assert.ok(gatewayError instanceof Error);
+  assert.equal(gatewayError.turnFailureLayer, 'gateway');
+  assert.equal(classifyTurnRecovery(gatewayError), 'recover');
+  assert.equal(turnRequestFailureState(gatewayError), null);
+});
+
+test('request-failure UI does not intercept fallback-safe, server, or network failures', () => {
+  assert.equal(turnRequestFailureState(hermesRequestError({ status: 404, body: 'missing' })), null);
+  assert.equal(turnRequestFailureState(hermesRequestError({ status: 503, body: 'offline' })), null);
+  assert.equal(turnRequestFailureState(new Error('socket closed')), null);
 });
 
 test('recovery selects the assistant after the latest matching user turn', () => {
@@ -148,4 +197,38 @@ test('both Browser surfaces preserve provider-rejected drafts without marking He
   assert.match(sidepanelSource, /classifyTurnRecovery\(streamError\)[\s\S]{0,120}=== 'reject'/);
   assert.match(appSource, /hermesRequestError\(\{[\s\S]{0,180}status:\s*response\.status[\s\S]{0,180}body:\s*await response\.text\(\)/);
   assert.match(appSource, /turnRequestFailureState\(error\)[\s\S]{0,700}renderConnectionTruth\(\{\s*status:\s*'online'\s*\}\)/);
+});
+
+test('fallback REST and dashboard WS transports retain typed provider failures', () => {
+  const fallbackSessionStart = sidepanelSource.indexOf('async function fallbackSessionChat');
+  const fallbackCompletionsStart = sidepanelSource.indexOf('async function fallbackChatCompletions');
+  const askHermesStart = sidepanelSource.indexOf('async function askHermes');
+  assert.match(
+    sidepanelSource.slice(fallbackSessionStart, fallbackCompletionsStart),
+    /if \(!response\.ok\) throw hermesRequestError\(/,
+  );
+  assert.match(
+    sidepanelSource.slice(fallbackCompletionsStart, askHermesStart),
+    /if \(!response\.ok\) throw hermesRequestError\(/,
+  );
+
+  const sidepanelDashboardStart = sidepanelSource.indexOf('async function streamRemoteWsChat');
+  const sidepanelStreamStart = sidepanelSource.indexOf('async function streamSessionChat');
+  const sidepanelDashboard = sidepanelSource.slice(sidepanelDashboardStart, sidepanelStreamStart);
+  assert.match(sidepanelDashboard, /WS_EVENTS\.messageComplete[\s\S]*hermesGatewayTurnError/);
+  assert.match(sidepanelDashboard, /WS_EVENTS\.error[\s\S]*hermesGatewayTurnError/);
+
+  const webDashboardStart = appSource.indexOf('async function streamDashboardPrompt');
+  const webCapabilitiesStart = appSource.indexOf('async function loadGatewayCapabilities');
+  const webDashboard = appSource.slice(webDashboardStart, webCapabilitiesStart);
+  assert.match(webDashboard, /WS_EVENTS\.messageComplete[\s\S]*hermesGatewayTurnError/);
+  assert.match(webDashboard, /WS_EVENTS\.error[\s\S]*hermesGatewayTurnError/);
+
+  const streamCatchStart = sidepanelSource.indexOf('} catch (streamError) {', sidepanelSource.indexOf('async function askHermes'));
+  const streamCatchEnd = sidepanelSource.indexOf('const finalAnswer', streamCatchStart);
+  const streamCatch = sidepanelSource.slice(streamCatchStart, streamCatchEnd);
+  assert.ok(
+    streamCatch.indexOf("classifyTurnRecovery(streamError)") < streamCatch.indexOf('isRemoteWsMode()'),
+    'request rejection classification must run before remote-dashboard connection diagnostics',
+  );
 });


### PR DESCRIPTION
## Summary

- retain HTTP status and redacted provider detail when the side panel uses either non-streaming REST fallback
- classify Hermes dashboard `message.complete` terminal errors from the structured `error_surface` contract on both Browser surfaces
- run provider-rejection classification before remote-dashboard reachability diagnostics
- preserve the existing no-replay, draft-restoration, and connected-gateway behavior across sibling transports

## Why

A late senior review of #80 found that the primary stream path was fixed, but sibling non-stream REST and dashboard WebSocket paths could still discard structured provider failure metadata and fall into gateway diagnostics. This completes the same failure class without changing model-option policy.

## Verification

- RED: focused turn-recovery suite failed on missing dashboard shaping and untyped fallback errors
- GREEN: focused turn-recovery suite passed 17/17
- `npm run test`: 1,274/1,274 passed
- `npm run lint`: 0 errors
- `npm run build`: passed
- `npm run check:js`: passed
- loaded-extension Chrome E2E: PASS, including one 404 stream attempt followed by exactly one 400 fallback request, restored draft, redacted provider detail, and connected gateway state
- `git diff --check`: passed
- GitNexus change detection: five intended files, 31 affected flows, critical transitive risk reviewed

## Risk

The turn classifier has broad transitive reach, but the implementation is limited to shared error shaping and four transport call sites. Generic gateway, network, server, and authentication failures retain their existing diagnostic paths.

Follow-up to #79 and #80.
