### PR TITLE
fix(sidepanel): prevent Edge panel reloads during tab changes

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -85,6 +85,7 @@ const browserControlRuntime = createBrowserControlRuntime({
   },
 });
 let cachedPanelResidencyMode = DEFAULT_PANEL_RESIDENCY_MODE;
+let panelResidencyHydrated = false;
 
 const controllerConnector = createControllerConnector({
   fetchImpl: globalThis.fetch?.bind(globalThis),
@@ -464,6 +465,8 @@ async function refreshPanelResidencyModeFromStorage() {
   } catch (error) {
     console.warn('[Hermes Browser] Could not read panel residency setting:', error);
     cachedPanelResidencyMode = DEFAULT_PANEL_RESIDENCY_MODE;
+  } finally {
+    panelResidencyHydrated = true;
   }
   return cachedPanelResidencyMode;
 }
@@ -534,7 +537,16 @@ async function configureSidePanel() {
 }
 
 function reapplyPanelResidencyForTab(tabId) {
-  applyPanelResidencyMode(cachedPanelResidencyMode, { tabId })
+  // The worker starts with the tab-attached default. Do not overwrite an
+  // existing global panel while its persisted residency mode is still loading.
+  if (!panelResidencyHydrated) {
+    return refreshPanelResidencyModeFromStorage()
+      .then(() => reapplyPanelResidencyForTab(tabId));
+  }
+  // A global panel has one default path for the window. Reapplying identical
+  // options for every activated tab can recreate that document in Edge.
+  if (cachedPanelResidencyMode === PANEL_RESIDENCY_MODES.GLOBAL) return;
+  return applyPanelResidencyMode(cachedPanelResidencyMode, { tabId })
     .catch((error) => console.warn('[Hermes Browser] Could not apply panel residency setting:', error));
 }
 
@@ -728,9 +740,13 @@ function openHermesPanelFromGesture(tab) {
         }
         return true;
       })
-      .catch(() => openHermesPanelFallback(tab, browserId, panelUrl));
-  } catch {
-    return openHermesPanelFallback(tab, browserId, panelUrl);
+      .catch((error) => {
+        console.warn('[Hermes Browser] Native side panel open rejected; preserving the browser-owned side-panel action instead of opening a full tab:', error);
+        return true;
+      });
+  } catch (error) {
+    console.warn('[Hermes Browser] Native side panel open threw; preserving the browser-owned side-panel action instead of opening a full tab:', error);
+    return true;
   }
 }
 
@@ -898,16 +914,19 @@ browserApi.storage?.onChanged?.addListener?.((changes, areaName) => {
       .catch((error) => console.warn('[Hermes Browser] Controller settings rebind failed:', error));
   }
   let changed = false;
-  if (changes.hermesBrowserSettings?.newValue?.panelResidencyMode) {
-    cachedPanelResidencyMode = normalizePanelResidencyMode(changes.hermesBrowserSettings.newValue.panelResidencyMode);
-    changed = true;
-  } else if (changes.panelResidencyMode?.newValue) {
-    cachedPanelResidencyMode = normalizePanelResidencyMode(changes.panelResidencyMode.newValue);
-    changed = true;
+  if (Object.hasOwn(changes, 'hermesBrowserSettings')) {
+    const previousMode = cachedPanelResidencyMode;
+    cachedPanelResidencyMode = normalizePanelResidencyMode(changes.hermesBrowserSettings?.newValue?.panelResidencyMode);
+    changed = cachedPanelResidencyMode !== previousMode;
+  } else if (Object.hasOwn(changes, 'panelResidencyMode')) {
+    const previousMode = cachedPanelResidencyMode;
+    cachedPanelResidencyMode = normalizePanelResidencyMode(changes.panelResidencyMode?.newValue);
+    changed = cachedPanelResidencyMode !== previousMode;
   }
   if (changed) {
-    activeBrowserTabId()
-      .then((tabId) => reapplyPanelResidencyForTab(tabId));
+    return activeBrowserTabId()
+      .then((tabId) => applyPanelResidencyMode(cachedPanelResidencyMode, { tabId }))
+      .catch((error) => console.warn('[Hermes Browser] Could not apply changed panel residency setting:', error));
   }
 });
 browserApi.runtime.onMessage.addListener((message, sender, sendResponse) => {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -10599,57 +10599,28 @@ async function testConnection() {
     if (!connectionController.isCurrent(generation)) return;
     if (!apiCredentialSatisfied(settings) && gatewayCapabilities.browserPairing && automaticApiPairingAllowed(settings)) {
       await connectApiWithPairing();
-      if (!connectionController.isCurrent(generation)) return;
-      if (!apiCredentialSatisfied(settings)) {
+      if (!isConnected()) {
+        setTestConnectionBusy(false);
+        flashTestConnectionResult(false);
         throw new Error('Pairing was not completed. Approve the Hermes Browser request in the opened tab, then test again.');
       }
-      await loadGatewayCapabilities({ quiet: true, healthOk: true });
+      setTestConnectionBusy(false);
+      flashTestConnectionResult(true);
+      return;
     }
 
-    const modelsResponse = await apiFetch('/v1/models', { method: 'GET' });
-    const modelsPayload = await readJsonResponse(modelsResponse);
+    const readiness = await runPanelConnectionReadiness({ restoreSettings: false });
     if (!connectionController.isCurrent(generation)) return;
-    let degradedDiagnostic = null;
-    if (!modelsResponse.ok) {
-      if (isRemoteMode()) {
-        const remoteDiagnostic = classifyRemoteGatewaySetup({
-          url: settings.gatewayUrl,
-          healthOk: true,
-          status: modelsResponse.status,
-          body: JSON.stringify(modelsPayload).slice(0, 700),
-        });
-        lastRemoteDiagnostic = remoteDiagnostic;
-        renderRemoteDiagnostics(remoteDiagnostic);
-      }
-      const diagnostic = classifyGatewayError(`Health OK, auth/model probe failed (${modelsResponse.status}): ${JSON.stringify(modelsPayload).slice(0, 500)}`);
-      if (diagnostic.probeStatus === 'degraded') {
-        degradedDiagnostic = diagnostic;
-      } else {
-        throw new Error(`Health OK, auth/model probe failed (${modelsResponse.status}): ${JSON.stringify(modelsPayload).slice(0, 500)}`);
-      }
-    } else {
-      await loadModels({ quiet: true });
-    }
-    await loadSkills({ quiet: true });
-    await loadProfiles({ quiet: true });
-
-    const hasSessionRoutes = await ensureHermesSession();
-    if (!connectionController.isCurrent(generation)) return;
-    if (degradedDiagnostic) {
-      connectionController.transition(generation, CONNECTION_STATES.DEGRADED, { errorKind: degradedDiagnostic.kind });
-      setStatus('warn', 'Hermes gateway connected with runtime warning', degradedDiagnostic.detail);
-      markGatewayDegraded(degradedDiagnostic.detail);
-    } else {
-      if (!connectionController.transition(generation, CONNECTION_STATES.READY, { gateway: 'api' })) return;
-      setStatus(
-        'ok',
-        hasSessionRoutes ? 'Hermes gateway + session API connected' : 'Hermes gateway connected',
-        hasSessionRoutes ? normalizeGatewayUrl(settings.gatewayUrl) : `${normalizeGatewayUrl(settings.gatewayUrl)} - OpenAI-compatible fallback mode`,
-      );
-      markGatewayReachable(normalizeGatewayUrl(settings.gatewayUrl));
-      lastRemoteDiagnostic = null;
-      renderRemoteDiagnostics(null);
-    }
+    const hasSessionRoutes = Boolean(readiness.sessionId) || sessionRoutesAvailable !== false;
+    if (!connectionController.transition(generation, CONNECTION_STATES.READY, { gateway: 'api' })) return;
+    setStatus(
+      'ok',
+      hasSessionRoutes ? 'Hermes gateway + session API connected' : 'Hermes gateway connected',
+      hasSessionRoutes ? normalizeGatewayUrl(settings.gatewayUrl) : `${normalizeGatewayUrl(settings.gatewayUrl)} - OpenAI-compatible fallback mode`,
+    );
+    markGatewayReachable(normalizeGatewayUrl(settings.gatewayUrl));
+    lastRemoteDiagnostic = null;
+    renderRemoteDiagnostics(null);
 
     settings = { ...settings, lastConnectionTestedAt: Date.now() };
     await browserApi.storage.local.set({ hermesBrowserSettings: settings });

--- a/tests/browser-control-turn-integration.test.mjs
+++ b/tests/browser-control-turn-integration.test.mjs
@@ -98,3 +98,12 @@ test('successful pairing re-runs readiness so the startup gate dismisses', () =>
   assert.ok(tokenIndex >= 0 && tokenIndex < readinessIndex);
   assert.doesNotMatch(pairing.slice(readinessIndex), /loadModels\(\{ quiet: true \}\)/);
 });
+
+test('successful manual connection tests run readiness to dismiss the startup gate', () => {
+  const start = sidepanel.indexOf('async function testConnection()');
+  const end = sidepanel.indexOf('\nfunction closeFloatingPanels()', start);
+  const testConnection = sidepanel.slice(start, end);
+
+  assert.ok(start >= 0 && end > start);
+  assert.match(testConnection, /await runPanelConnectionReadiness\(\{ restoreSettings: false \}\)/);
+});

--- a/tests/browser-runtime.test.mjs
+++ b/tests/browser-runtime.test.mjs
@@ -275,8 +275,10 @@ function createBackgroundHarness({
   let actionHandler = null;
   let installedHandler = null;
   let startupHandler = null;
+  let activatedHandler = null;
   let contextMenuHandler = null;
   let runtimeMessageHandler = null;
+  let storageChangedHandler = null;
   let releaseStorageGet = null;
   const storageGetGate = blockStorageGet
     ? new Promise((resolve) => { releaseStorageGet = resolve; })
@@ -297,7 +299,7 @@ function createBackgroundHarness({
           return { hermesBrowserSettings: { panelResidencyMode } };
         },
       },
-      onChanged: { addListener() {} },
+      onChanged: { addListener(handler) { storageChangedHandler = handler; } },
     },
     action: {
       setPopup: async () => {},
@@ -321,7 +323,7 @@ function createBackgroundHarness({
         updatedTabs.push({ tabId, options });
         return extensionTabs.find((tab) => tab.id === tabId) || null;
       },
-      onActivated: { addListener() {} },
+      onActivated: { addListener(handler) { activatedHandler = handler; } },
     },
     sidePanel: {
       setPanelBehavior: async () => {},
@@ -365,8 +367,10 @@ function createBackgroundHarness({
     get actionHandler() { return actionHandler; },
     get installedHandler() { return installedHandler; },
     get startupHandler() { return startupHandler; },
+    get activatedHandler() { return activatedHandler; },
     get contextMenuHandler() { return contextMenuHandler; },
     get runtimeMessageHandler() { return runtimeMessageHandler; },
+    get storageChangedHandler() { return storageChangedHandler; },
     releaseStorageGet() { releaseStorageGet?.(); },
   };
 }
@@ -396,6 +400,27 @@ test('background registers MV3 listeners before locale and residency storage hyd
   }
 });
 
+test('tab activation waits for global residency hydration before applying options', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness({ panelResidencyMode: 'global', blockStorageGet: true });
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?activation-before-residency-hydration=${Date.now()}`);
+    assert.equal(typeof harness.activatedHandler, 'function');
+    const activation = harness.activatedHandler({ tabId: 42 });
+    assert.deepEqual(harness.sidePanelOptions, [], 'the default tab-attached mode must not be applied before storage hydration');
+
+    harness.releaseStorageGet();
+    await activation;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(harness.sidePanelOptions, [], 'hydrated global residency must not reconfigure the panel on activation');
+  } finally {
+    harness.releaseStorageGet();
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test('global residency updates only the default path and preserves existing tab overrides', async () => {
   const originalChrome = globalThis.chrome;
   const harness = createBackgroundHarness({ panelResidencyMode: 'global' });
@@ -413,6 +438,80 @@ test('global residency updates only the default path and preserves existing tab 
       harness.sidePanelOptions.some((options) => Object.hasOwn(options, 'tabId')),
       false,
       'global mode must not rewrite tabs that already own attached panel documents',
+    );
+
+    assert.equal(typeof harness.activatedHandler, 'function');
+    await harness.activatedHandler({ tabId: 42 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(
+      harness.sidePanelOptions,
+      [{ path: 'sidepanel.html?panel=global', enabled: true }],
+      'tab activation must not reconfigure the global panel document',
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('saving global residency configures the shared default without an activation reapply', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness();
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?global-residency-setting=${Date.now()}`);
+    assert.equal(typeof harness.storageChangedHandler, 'function');
+    await harness.storageChangedHandler({
+      hermesBrowserSettings: { newValue: { panelResidencyMode: 'global' } },
+    }, 'local');
+    assert.deepEqual(harness.sidePanelOptions, [{
+      path: 'sidepanel.html?panel=global',
+      enabled: true,
+    }]);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('saving an API key does not reconfigure an unchanged global panel', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness({ panelResidencyMode: 'global' });
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?global-residency-api-key=${Date.now()}`);
+    await harness.installedHandler();
+    await harness.storageChangedHandler({
+      hermesBrowserSettings: {
+        oldValue: { panelResidencyMode: 'global', apiKey: 'old-token' },
+        newValue: { panelResidencyMode: 'global', apiKey: 'new-token' },
+      },
+    }, 'local');
+    assert.deepEqual(
+      harness.sidePanelOptions,
+      [{ path: 'sidepanel.html?panel=global', enabled: true }],
+      'non-residency settings changes must not recreate the global panel document',
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test('global settings writes do not reconfigure when Edge omits the old storage value', async () => {
+  const originalChrome = globalThis.chrome;
+  const harness = createBackgroundHarness({ panelResidencyMode: 'global' });
+  globalThis.chrome = harness.chromeApi;
+
+  try {
+    await import(`../extension/background.js?global-residency-missing-old-value=${Date.now()}`);
+    await harness.installedHandler();
+    await harness.storageChangedHandler({
+      hermesBrowserSettings: { newValue: { panelResidencyMode: 'global', apiKey: 'new-token' } },
+    }, 'local');
+    assert.deepEqual(
+      harness.sidePanelOptions,
+      [{ path: 'sidepanel.html?panel=global', enabled: true }],
+      'missing oldValue must not recreate an already-configured global panel',
     );
   } finally {
     globalThis.chrome = originalChrome;
@@ -554,7 +653,7 @@ test('background action does not open a full tab when side-panel visibility conf
   }
 });
 
-test('background action does not re-open the side panel after a failed tab-scoped gesture attempt', async () => {
+test('background action never falls back to a full tab after a failed native gesture attempt', async () => {
   const originalChrome = globalThis.chrome;
   const harness = createBackgroundHarness({
     sidePanelOpen: async (options) => {
@@ -572,7 +671,7 @@ test('background action does not re-open the side panel after a failed tab-scope
       [{ tabId: 7 }],
       'a failed gesture attempt must not trigger a second side-panel open',
     );
-    assert.equal(harness.createdTabs.length, 1, 'the gesture-free fallback must open exactly one extension tab');
+    assert.equal(harness.createdTabs.length, 0, 'a native side-panel browser must not replace the panel with a full extension tab');
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/tests/common.test.mjs
+++ b/tests/common.test.mjs
@@ -1547,7 +1547,6 @@ test('sidepanel falls back to visible voice dictation tab when sidepanel microph
 test('connect and startup sync Hermes models, sessions, skills, and profiles from the gateway', () => {
   const source = readFileSync(new URL('../extension/sidepanel.js', import.meta.url), 'utf8');
   assert.match(source, /await loadModels\(\{ quiet: true \}\);\s*await loadSkills\(\{ quiet: true \}\);\s*await loadProfiles\(\{ quiet: true \}\);\s*await loadSessions\(\{ quiet: true \}\);\s*await initializeSessionForPanelOpen\(\{ focus: false \}\);/s);
-  assert.match(source, /apiFetch\('\/v1\/models'/);
   assert.ok(
     source.indexOf('discoverModelsFromRegistry({ apiFetch, readJsonResponse, refresh })') > -1
       && source.indexOf('discoverModelsFromRegistry({ apiFetch, readJsonResponse, refresh })') < source.indexOf('discoverModelsFromDashboard({'),


### PR DESCRIPTION
## What does this PR do?

Fixes Edge side-panel reloads caused by Manifest V3 worker lifecycle races and native side-panel fallback behavior.

- Wait for persisted panel residency before applying options after tab activation.
- Reconfigure panel residency only when the cached mode actually changes, including when Edge omits `oldValue` from a storage event.
- Preserve Edge's browser-owned native side-panel action if a manual open rejects instead of opening a full extension tab.
- Route successful manual connection tests through canonical startup readiness so the startup gate dismisses only after model and session readiness complete.
- Settle automatic-pairing test feedback from the pairing generation.

## Related Issue / Phase

No matching upstream issue or PR exists. This is a browser-compatibility fix reproduced against Edge side-panel behavior.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🌐 Browser compatibility
- [x] ✅ Tests

## Changes Made

- `extension/background.js`
  - Prevents activation-time residency application before storage hydration.
  - Preserves global panels across non-residency settings writes.
  - Retains the native browser side-panel action when manual opening rejects.

- `extension/sidepanel.js`
  - Uses canonical readiness after a successful manual API connection test.
  - Finishes automatic-pairing test feedback from the active pairing generation.

- Tests
  - Cover global activation during delayed residency hydration.
  - Cover Edge storage changes without `oldValue`, API-key saves, and native-action failures.
  - Cover startup readiness after successful manual connection tests.

## How to Test

1. `PYTHON="$(uv python find)" pnpm run verify`
2. `pnpm run lint`
3. `pnpm run build`
4. Reload the unpacked extension from `dist/` in Edge.
5. Enable **Keep open across tabs**, then:
   - save a changed API key and run **Test connection**;
   - navigate to a localhost dashboard route and return to another tab;
   - open and leave a redirect-heavy OIDC login tab;
   - click the extension toolbar icon.
6. Confirm that the native side panel remains intact, startup proceeds after a successful test, and no full extension tab opens.

## Browser Evidence

- Microsoft Edge 151.0.4129.107 (64-bit)
- Firefox 154.0.1 (64-bit), chat/context/sidebar validation

Firefox remains chat-and-context only; real-tab control is Chromium-only.

## Verification

- `pnpm run lint` — passed
- `PYTHON="$(uv python find)" pnpm run verify` — 1282/1282 passed
- `pnpm run build` — passed
- Firefox package lint — 0 errors, 16 existing `innerHTML` warnings
- Live Edge CDP check: opened the LiteLLM localhost route, returned to the prior debug tab, and observed no side-panel frame navigation, execution-context destruction, or startup reset.

## Screenshots / Logs

A public-safe CDP recording was captured for review. It shows the global panel ready, a local-dashboard navigation/return event with zero panel reload signals, and the panel still ready afterward.

<img width="1200" height="650" alt="edge-panel-residency-cdp" src="https://github.com/user-attachments/assets/2b05d93f-0642-467f-8c64-4dab46dc78d8" />


## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] All tests pass and project verification completed
- [x] JavaScript syntax, manifest, and locale validation pass
- [x] Context consent and redaction rules are preserved
- [x] No hardcoded secrets, tokens, or unredacted credentials
- [x] Tested target browser(s)
