### PR TITLE
Fix consent-gated tab scope appearing to do nothing

### DIFF
--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -2478,6 +2478,29 @@ body.startup-active .topbar #startupConnectButton:not([hidden]):hover {
   display: grid;
   gap: 2px;
 }
+.context-scope-consent-notice {
+  flex: 0 0 auto;
+  display: grid;
+  gap: 5px;
+  margin-bottom: 6px;
+  padding: 8px;
+  border: 1px solid rgba(var(--hermes-accent-rgb),0.42);
+  border-radius: 5px;
+  background: rgba(var(--hermes-accent-rgb),0.1);
+  color: rgba(var(--hermes-fg-rgb),0.9);
+  font-size: 10px;
+  line-height: 1.35;
+}
+.context-scope-consent-notice strong { color: var(--hermes-ink); font-size: 11px; }
+.context-scope-consent-notice > span { color: rgba(var(--hermes-fg-rgb),0.72); }
+.context-scope-menu .context-scope-consent-action {
+  justify-content: center;
+  margin-top: 2px;
+  border: 1px solid rgba(var(--hermes-accent-rgb),0.4);
+  background: rgba(var(--hermes-accent-rgb),0.12);
+  color: var(--hermes-ink);
+  text-align: center;
+}
 .context-scope-search {
   flex: 0 0 auto;
   margin: 5px 0 4px;

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -2333,9 +2333,34 @@ async function applyContextScope(nextScope, { ensureSession = false } = {}) {
   await refreshContext();
 }
 
+function requireContextConsentForScope(nextScope) {
+  const requested = normalizeContextScope(nextScope);
+  if (requested.mode === CONTEXT_SCOPE_MODES.CHAT_ONLY) return true;
+  const gate = effectiveContextGate(requested);
+  if (gate.allowed) return true;
+
+  openSettingsDialog();
+  const needsConnection = gate.reason === 'principal-unavailable';
+  showOperationToast({
+    kind: 'warn',
+    title: needsConnection ? 'Verify this connection first' : 'Approve page context sharing',
+    detail: needsConnection
+      ? 'Reconnect or test this connection, then approve page context sharing.'
+      : 'Enable “Share page context with this connection,” then choose the tab scope again.',
+    duration: 9000,
+  });
+  if (!needsConnection) {
+    els.browserContextConsentControl?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    els.browserContextConsentInput?.focus({ preventScroll: true });
+  }
+  return false;
+}
+
 async function pinContextTab(tab) {
   if (!tab?.id) return;
-  await applyContextScope(contextScopeFromTab(tab, contextScope), { ensureSession: true });
+  const nextScope = contextScopeFromTab(tab, contextScope);
+  if (!requireContextConsentForScope(nextScope)) return;
+  await applyContextScope(nextScope, { ensureSession: true });
 }
 
 async function pinContextTabById(tabId) {
@@ -2355,7 +2380,7 @@ async function pinContextTabById(tabId) {
 }
 
 async function unlockContextScope() {
-  await applyContextScope({
+  const nextScope = {
     ...contextScope,
     mode: CONTEXT_SCOPE_MODES.FOLLOW_ACTIVE,
     pinnedTabId: null,
@@ -2363,7 +2388,9 @@ async function unlockContextScope() {
     pinnedTitle: '',
     pinnedUrl: '',
     selectedTabIds: [],
-  });
+  };
+  if (!requireContextConsentForScope(nextScope)) return;
+  await applyContextScope(nextScope);
 }
 
 function setGatewayCapabilities(caps) {

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -2205,10 +2205,38 @@ function renderContextScopePromptControls(tabs = currentContext.tabs || []) {
   return section;
 }
 
-function renderContextScopeMenu(query = '', { focusSearch = false } = {}) {
+function renderContextScopeConsentNotice(requestedScope = contextScope) {
+  const gate = effectiveContextGate(requestedScope);
+  if (gate.allowed) return null;
+
+  const needsConnection = gate.reason === 'principal-unavailable';
+  const notice = document.createElement('section');
+  notice.className = 'context-scope-consent-notice';
+  notice.setAttribute('role', 'status');
+
+  const title = document.createElement('strong');
+  title.textContent = translateUiText(needsConnection ? 'Verify this connection first' : 'Page context approval required');
+  const detail = document.createElement('span');
+  detail.textContent = translateUiText(needsConnection
+    ? 'Reconnect or test this connection before choosing a tab scope.'
+    : 'Approve “Share page context with this connection” before choosing a tab scope.');
+  const action = document.createElement('button');
+  action.type = 'button';
+  action.className = 'context-scope-consent-action';
+  action.dataset.scopeAction = 'open-context-consent';
+  action.dataset.contextConsentReason = gate.reason || '';
+  action.textContent = translateUiText('Open Settings');
+  notice.append(title, detail, action);
+  return notice;
+}
+
+function renderContextScopeMenu(query = '', { focusSearch = false, consentScope = contextScope } = {}) {
   if (!els.contextScopeMenu) return;
   const searchQuery = String(query || '');
   els.contextScopeMenu.innerHTML = '';
+
+  const consentNotice = renderContextScopeConsentNotice(consentScope);
+  if (consentNotice) els.contextScopeMenu.appendChild(consentNotice);
 
   const actions = document.createElement('div');
   actions.className = 'context-scope-actions';
@@ -2339,20 +2367,10 @@ function requireContextConsentForScope(nextScope) {
   const gate = effectiveContextGate(requested);
   if (gate.allowed) return true;
 
-  openSettingsDialog();
-  const needsConnection = gate.reason === 'principal-unavailable';
-  showOperationToast({
-    kind: 'warn',
-    title: needsConnection ? 'Verify this connection first' : 'Approve page context sharing',
-    detail: needsConnection
-      ? 'Reconnect or test this connection, then approve page context sharing.'
-      : 'Enable “Share page context with this connection,” then choose the tab scope again.',
-    duration: 9000,
+  renderContextScopeMenu('', { consentScope: requested });
+  requestAnimationFrame(() => {
+    els.contextScopeMenu?.querySelector('[data-scope-action="open-context-consent"]')?.focus();
   });
-  if (!needsConnection) {
-    els.browserContextConsentControl?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-    els.browserContextConsentInput?.focus({ preventScroll: true });
-  }
   return false;
 }
 
@@ -11484,6 +11502,21 @@ function bindEvents() {
     if (action === 'prompt-tabs-none') {
       setPromptTabsSelection([]);
       rerenderContextScopePromptSelectionPreservingScroll(currentContextScopeSearchQuery());
+      return;
+    }
+    if (action === 'open-context-consent') {
+      const gateReason = button.dataset.contextConsentReason || '';
+      els.contextScopeMenu.hidden = true;
+      renderContextScopeControls();
+      openSettingsDialog();
+      requestAnimationFrame(() => {
+        if (gateReason === 'principal-unavailable') {
+          els.testConnectionButton?.focus({ preventScroll: true });
+          return;
+        }
+        els.browserContextConsentControl?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        els.browserContextConsentInput?.focus({ preventScroll: true });
+      });
       return;
     }
 

--- a/tests/phase2-consent-integration.test.mjs
+++ b/tests/phase2-consent-integration.test.mjs
@@ -41,6 +41,19 @@ test('the Side Panel applies the final consent gate after every turn-time scope 
   assert.match(sender, /const gatedContextOverride = contextGate\.allowed \? contextOverride : null/);
 });
 
+test('tab-scope actions send users to the exact consent control instead of appearing to do nothing', () => {
+  const guard = sidepanel.match(/function requireContextConsentForScope\([\s\S]*?\n\}/)?.[0] || '';
+  const pin = sidepanel.match(/async function pinContextTab\([\s\S]*?\n\}/)?.[0] || '';
+  const unlock = sidepanel.match(/async function unlockContextScope\([\s\S]*?\n\}/)?.[0] || '';
+  assert.match(guard, /effectiveContextGate\(requested\)/);
+  assert.match(guard, /openSettingsDialog\(\)/);
+  assert.match(guard, /Share page context with this connection/);
+  assert.match(guard, /browserContextConsentControl\?\.scrollIntoView/);
+  assert.match(guard, /browserContextConsentInput\?\.focus/);
+  assert.ok(pin.indexOf('requireContextConsentForScope(nextScope)') < pin.indexOf('applyContextScope(nextScope'));
+  assert.ok(unlock.indexOf('requireContextConsentForScope(nextScope)') < unlock.indexOf('applyContextScope(nextScope'));
+});
+
 test('non-loopback Remote API is consent-gated as strictly as Cloud and dashboard transport', () => {
   const renderer = sidepanel.match(/function renderBrowserContextConsentControl\([\s\S]*?\n\}/)?.[0] || '';
   assert.match(renderer, /consentRequiredForConnection/);

--- a/tests/phase2-consent-integration.test.mjs
+++ b/tests/phase2-consent-integration.test.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 
 const sidepanel = readFileSync(new URL('../extension/sidepanel.js', import.meta.url), 'utf8');
 const sidepanelHtml = readFileSync(new URL('../extension/sidepanel.html', import.meta.url), 'utf8');
+const sidepanelCss = readFileSync(new URL('../extension/sidepanel.css', import.meta.url), 'utf8');
 const fulltab = readFileSync(new URL('../extension/app.js', import.meta.url), 'utf8');
 const fulltabHtml = readFileSync(new URL('../extension/app.html', import.meta.url), 'utf8');
 const background = readFileSync(new URL('../extension/background.js', import.meta.url), 'utf8');
@@ -41,15 +42,22 @@ test('the Side Panel applies the final consent gate after every turn-time scope 
   assert.match(sender, /const gatedContextOverride = contextGate\.allowed \? contextOverride : null/);
 });
 
-test('tab-scope actions send users to the exact consent control instead of appearing to do nothing', () => {
+test('tab-scope actions render an inline consent warning instead of appearing to do nothing', () => {
+  const notice = sidepanel.match(/function renderContextScopeConsentNotice\([\s\S]*?\n\}/)?.[0] || '';
   const guard = sidepanel.match(/function requireContextConsentForScope\([\s\S]*?\n\}/)?.[0] || '';
   const pin = sidepanel.match(/async function pinContextTab\([\s\S]*?\n\}/)?.[0] || '';
   const unlock = sidepanel.match(/async function unlockContextScope\([\s\S]*?\n\}/)?.[0] || '';
+  assert.match(notice, /Page context approval required/);
+  assert.match(notice, /open-context-consent/);
+  assert.match(notice, /contextConsentReason = gate\.reason/);
+  assert.match(notice, /Open Settings/);
   assert.match(guard, /effectiveContextGate\(requested\)/);
-  assert.match(guard, /openSettingsDialog\(\)/);
-  assert.match(guard, /Share page context with this connection/);
-  assert.match(guard, /browserContextConsentControl\?\.scrollIntoView/);
-  assert.match(guard, /browserContextConsentInput\?\.focus/);
+  assert.match(guard, /renderContextScopeMenu\('', \{ consentScope: requested \}\)/);
+  assert.match(guard, /open-context-consent/);
+  assert.doesNotMatch(guard, /openSettingsDialog\(\)/);
+  assert.match(sidepanel, /action === 'open-context-consent'[\s\S]*contextConsentReason[\s\S]*openSettingsDialog\(\)/);
+  assert.match(sidepanelCss, /\.context-scope-consent-notice/);
+  assert.match(sidepanelCss, /\.context-scope-consent-action/);
   assert.ok(pin.indexOf('requireContextConsentForScope(nextScope)') < pin.indexOf('applyContextScope(nextScope'));
   assert.ok(unlock.indexOf('requireContextConsentForScope(nextScope)') < unlock.indexOf('applyContextScope(nextScope'));
 });


### PR DESCRIPTION
## Summary

- keep non-loopback Remote API page context gated behind connection-scoped consent
- show an inline warning in the context-scope menu when Pin/Follow is blocked
- keep the menu open and focus an explicit **Open Settings** action
- after that action is clicked, focus either **Test Connection** or the exact **Share page context with this connection** toggle
- never grant consent automatically
- add regression coverage for the blocked-scope UX

Fixes #92

## Testing

- `npm test` — 1,278 passing
- `node --test tests/phase2-consent-integration.test.mjs` — 9 passing
- `node --check extension/sidepanel.js`
- `npx eslint extension/sidepanel.js tests/phase2-consent-integration.test.mjs` — 0 errors (71 existing warnings)
- `git diff --check`
