### PR TITLE
fix(profiles): discover authenticated local dashboard roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Local gateway Bot Mode profile discovery when Dashboard authentication replaces the token-bearing root page with sign-in HTML; the extension now recognizes the authenticated dashboard and uses its public status profile roster (#99).
+
 ## [0.3.2] - 2026-09-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Local gateway Bot Mode profile discovery when Dashboard authentication replaces the token-bearing root page with sign-in HTML; the extension now recognizes the authenticated dashboard and uses its public status profile roster (#99).
+- Fixed Local gateway Bot Mode profile discovery when Dashboard authentication replaces the token-bearing root page with sign-in HTML; public status now identifies the dashboard, while the existing explicitly trusted signed-in tab and one-use WebSocket ticket flow authenticates the usable profile roster (#99).
 
 ## [0.3.2] - 2026-09-05
 

--- a/extension/lib/dashboard-bridge.mjs
+++ b/extension/lib/dashboard-bridge.mjs
@@ -1,4 +1,4 @@
-// Ticket broker for the OAuth-gated dashboard.
+// Ticket broker for authentication-gated dashboards.
 //
 // The dashboard mints a WebSocket ticket only on a cookie-authenticated
 // POST /api/auth/ws-ticket. From a chrome-extension:// origin that request is
@@ -14,7 +14,9 @@
 export function originOf(url) {
   try {
     const parsed = new URL(String(url || ''));
-    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return '';
+    const loopbackHttp = parsed.protocol === 'http:'
+      && ['127.0.0.1', 'localhost', '[::1]'].includes(parsed.hostname);
+    if ((parsed.protocol !== 'https:' && !loopbackHttp) || parsed.username || parsed.password) return '';
     return parsed.origin;
   } catch {
     return '';

--- a/extension/lib/desktop-roster.mjs
+++ b/extension/lib/desktop-roster.mjs
@@ -1,12 +1,12 @@
 // Desktop dashboard roster discovery (local API mode).
 //
-// Hermes Desktop serves its dashboard (and the /api/profiles roster endpoint)
-// on a random loopback port announced only on its own stdout. The sidecar API
-// server (8642) has no roster REST route, so in local-api mode the verified
-// roster is sourced from the desktop dashboard: GET / bootstraps
-// window.__HERMES_SESSION_TOKEN__, then GET /api/profiles?include_sessions=true
-// returns the roster. Extension host_permissions (http://127.0.0.1/*) exempt
-// these fetches from CORS.
+// Hermes Desktop serves its dashboard (and profile roster endpoints) on a
+// random loopback port announced only on its own stdout. The sidecar API server
+// (8642) has no roster REST route, so in local-api mode the verified roster is
+// sourced from the desktop dashboard. An unauthenticated dashboard
+// bootstraps a session token from GET / and exposes the rich /api/profiles
+// roster. An auth-gated dashboard serves its sign-in page there, so discovery
+// falls back to the public /api/status profile names.
 //
 // Port discovery is intentionally bounded: the last verified URL (cached in
 // chrome.storage.local), an explicit user-supplied URL, a sidecar candidate
@@ -28,6 +28,7 @@ const COMMON_DASHBOARD_PORTS = [
   62431, 59515, 46855, 57710, 57711, 43362, 50740, 50100, 50923, 51100,
 ];
 const SCAN_PROBE_TIMEOUT_MS = 200; // per-probe; loopback connection refused returns in <5ms
+const DASHBOARD_STATUS_PROBE_TIMEOUT_MS = 2_000;
 
 function fetchWithTimeout(fetchFn, url, options, timeoutMs) {
   if (typeof AbortSignal?.timeout !== 'function') return fetchFn(url, options);
@@ -39,6 +40,44 @@ export function extractDashboardSessionToken(html = '') {
   return match?.[1] || '';
 }
 
+function dashboardStatusUrl(baseUrl = '') {
+  try {
+    const url = new URL(String(baseUrl || '').trim());
+    url.hash = '';
+    url.search = '';
+    url.pathname = `${url.pathname.replace(/\/+$/, '')}/api/status`;
+    return url.toString();
+  } catch {
+    return '';
+  }
+}
+
+function rosterFromDashboardStatus(payload) {
+  if (typeof payload?.auth_required !== 'boolean' || !Array.isArray(payload.profiles)) return null;
+  const profiles = payload.profiles
+    .map((entry) => {
+      if (typeof entry === 'string') return { name: entry.trim() };
+      if (entry && typeof entry.name === 'string') return { ...entry, name: entry.name.trim() };
+      return null;
+    })
+    .filter((entry) => entry?.name);
+  if (profiles.length !== payload.profiles.length) return null;
+  return { profiles };
+}
+
+async function fetchPublicStatusRoster(baseUrl, fetchFn, timeoutMs) {
+  const statusUrl = dashboardStatusUrl(baseUrl);
+  if (!statusUrl) return null;
+  const response = await fetchWithTimeout(fetchFn, statusUrl, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  }, timeoutMs);
+  if (!response.ok) return null;
+  const payload = await response.json().catch(() => null);
+  return rosterFromDashboardStatus(payload);
+}
+
 async function isDesktopDashboard(baseUrl, fetchFn = globalThis.fetch?.bind(globalThis), headers = {}) {
   try {
     const response = await fetchWithTimeout(fetchFn, baseUrl, {
@@ -48,7 +87,8 @@ async function isDesktopDashboard(baseUrl, fetchFn = globalThis.fetch?.bind(glob
     }, SCAN_PROBE_TIMEOUT_MS);
     if (!response.ok) return false;
     const html = await response.text();
-    return Boolean(extractDashboardSessionToken(html));
+    if (extractDashboardSessionToken(html)) return true;
+    return Boolean(await fetchPublicStatusRoster(baseUrl, fetchFn, DASHBOARD_STATUS_PROBE_TIMEOUT_MS));
   } catch {
     return false;
   }
@@ -165,7 +205,11 @@ export async function fetchRosterFromDashboard({ baseUrl = '', fetchFn = globalT
   if (!rootResponse.ok) throw new Error(`dashboard-root-${rootResponse.status}`);
   const html = await rootResponse.text();
   const token = extractDashboardSessionToken(html);
-  if (!token) throw new Error('no-dashboard-session-token');
+  if (!token) {
+    const statusRoster = await fetchPublicStatusRoster(dashboardUrl, fetchFn, 2500);
+    if (statusRoster) return statusRoster;
+    throw new Error('no-dashboard-session-token');
+  }
 
   let rosterUrl;
   try {

--- a/extension/lib/desktop-roster.mjs
+++ b/extension/lib/desktop-roster.mjs
@@ -3,10 +3,10 @@
 // Hermes Desktop serves its dashboard (and profile roster endpoints) on a
 // random loopback port announced only on its own stdout. The sidecar API server
 // (8642) has no roster REST route, so in local-api mode the verified roster is
-// sourced from the desktop dashboard. An unauthenticated dashboard
-// bootstraps a session token from GET / and exposes the rich /api/profiles
-// roster. An auth-gated dashboard serves its sign-in page there, so discovery
-// falls back to the public /api/status profile names.
+// sourced from the desktop dashboard. An unauthenticated dashboard bootstraps
+// a session token from GET / and exposes the rich /api/profiles roster. An
+// auth-gated dashboard serves its sign-in page there; public /api/status only
+// identifies that dashboard before the signed-in tab mints a WebSocket ticket.
 //
 // Port discovery is intentionally bounded: the last verified URL (cached in
 // chrome.storage.local), an explicit user-supplied URL, a sidecar candidate
@@ -52,20 +52,18 @@ function dashboardStatusUrl(baseUrl = '') {
   }
 }
 
-function rosterFromDashboardStatus(payload) {
-  if (typeof payload?.auth_required !== 'boolean' || !Array.isArray(payload.profiles)) return null;
-  const profiles = payload.profiles
-    .map((entry) => {
-      if (typeof entry === 'string') return { name: entry.trim() };
-      if (entry && typeof entry.name === 'string') return { ...entry, name: entry.name.trim() };
-      return null;
-    })
-    .filter((entry) => entry?.name);
-  if (profiles.length !== payload.profiles.length) return null;
-  return { profiles };
+function isAuthenticatedDashboardStatus(payload) {
+  const profiles = payload?.profiles;
+  return payload?.auth_required === true
+    && typeof payload.version === 'string'
+    && Boolean(payload.version.trim())
+    && ['none', 'single', 'multiple', 'multiplex', 'unknown'].includes(payload.gateway_mode)
+    && Array.isArray(profiles)
+    && profiles.length > 0
+    && profiles.every((name) => typeof name === 'string' && Boolean(name.trim()));
 }
 
-async function fetchPublicStatusRoster(baseUrl, fetchFn, timeoutMs) {
+async function fetchAuthenticatedDashboardStatus(baseUrl, fetchFn, timeoutMs) {
   const statusUrl = dashboardStatusUrl(baseUrl);
   if (!statusUrl) return null;
   const response = await fetchWithTimeout(fetchFn, statusUrl, {
@@ -75,20 +73,33 @@ async function fetchPublicStatusRoster(baseUrl, fetchFn, timeoutMs) {
   }, timeoutMs);
   if (!response.ok) return null;
   const payload = await response.json().catch(() => null);
-  return rosterFromDashboardStatus(payload);
+  return isAuthenticatedDashboardStatus(payload) ? payload : null;
 }
 
-async function isDesktopDashboard(baseUrl, fetchFn = globalThis.fetch?.bind(globalThis), headers = {}) {
+function remainingProbeTimeout(deadlineAt, maximumMs) {
+  return Math.max(0, Math.min(maximumMs, deadlineAt - Date.now()));
+}
+
+async function isDesktopDashboard(
+  baseUrl,
+  fetchFn = globalThis.fetch?.bind(globalThis),
+  headers = {},
+  deadlineAt = Date.now() + DASHBOARD_STATUS_PROBE_TIMEOUT_MS,
+) {
   try {
+    const rootTimeoutMs = remainingProbeTimeout(deadlineAt, SCAN_PROBE_TIMEOUT_MS);
+    if (!rootTimeoutMs) return false;
     const response = await fetchWithTimeout(fetchFn, baseUrl, {
       method: 'GET',
       headers: { Accept: 'text/html', ...headers },
       cache: 'no-store',
-    }, SCAN_PROBE_TIMEOUT_MS);
+    }, rootTimeoutMs);
     if (!response.ok) return false;
     const html = await response.text();
     if (extractDashboardSessionToken(html)) return true;
-    return Boolean(await fetchPublicStatusRoster(baseUrl, fetchFn, DASHBOARD_STATUS_PROBE_TIMEOUT_MS));
+    const statusTimeoutMs = remainingProbeTimeout(deadlineAt, DASHBOARD_STATUS_PROBE_TIMEOUT_MS);
+    if (!statusTimeoutMs) return false;
+    return Boolean(await fetchAuthenticatedDashboardStatus(baseUrl, fetchFn, statusTimeoutMs));
   } catch {
     return false;
   }
@@ -98,7 +109,7 @@ async function scanLoopbackForDashboard(fetchFn, onProgress, headers = {}, deadl
   const probePorts = async (ports) => {
     const results = await Promise.all(ports.map(async (port) => {
       const candidate = `http://127.0.0.1:${port}`;
-      return (await isDesktopDashboard(candidate, fetchFn, headers)) ? candidate : null;
+      return (await isDesktopDashboard(candidate, fetchFn, headers, deadlineAt)) ? candidate : null;
     }));
     return results.find(Boolean) || '';
   };
@@ -156,7 +167,7 @@ export async function discoverLocalDashboardBaseUrl({
   }
   for (const candidate of candidates) {
     if (Date.now() >= deadlineAt) break;
-    if (await isDesktopDashboard(candidate, fetchFn, authHeaders)) return candidate;
+    if (await isDesktopDashboard(candidate, fetchFn, authHeaders, deadlineAt)) return candidate;
   }
 
   // Ask the sidecar gateway (fixed port, same machine) for live loopback
@@ -172,7 +183,7 @@ export async function discoverLocalDashboardBaseUrl({
           headers: authHeaders,
           cache: 'no-store',
         },
-        1500,
+        remainingProbeTimeout(deadlineAt, 1500),
       );
       if (response.ok) {
         const payload = await response.json().catch(() => null);
@@ -181,7 +192,7 @@ export async function discoverLocalDashboardBaseUrl({
           const candidate = `http://127.0.0.1:${Number(port)}`;
           if (tried.has(candidate)) continue;
           tried.add(candidate);
-          if (await isDesktopDashboard(candidate, fetchFn, authHeaders)) return candidate;
+          if (await isDesktopDashboard(candidate, fetchFn, authHeaders, deadlineAt)) return candidate;
         }
       }
     } catch {
@@ -206,8 +217,8 @@ export async function fetchRosterFromDashboard({ baseUrl = '', fetchFn = globalT
   const html = await rootResponse.text();
   const token = extractDashboardSessionToken(html);
   if (!token) {
-    const statusRoster = await fetchPublicStatusRoster(dashboardUrl, fetchFn, 2500);
-    if (statusRoster) return statusRoster;
+    const authenticatedStatus = await fetchAuthenticatedDashboardStatus(dashboardUrl, fetchFn, 2500);
+    if (authenticatedStatus) throw new Error('dashboard-authentication-required');
     throw new Error('no-dashboard-session-token');
   }
 

--- a/extension/sidepanel.js
+++ b/extension/sidepanel.js
@@ -208,7 +208,6 @@ import {
 } from './lib/bot-group-runtime.mjs';
 import {
   dashboardTrustPrompt,
-  discoverProfilesViaTab,
   findDashboardTab,
   isTrustedDashboardOrigin,
   mintWsTicket,
@@ -885,6 +884,7 @@ let botModeRosterNote = '';
 let profileWsConnection = null;
 let desktopDashboardDiscoveryPromise = null;
 let profileRichRosterPromise = null;
+let profileRichRosterAllowsTrust = false;
 let activeConversationTransport = 'rest';
 let activeDashboardWsConnection = null;
 let activeGroupProjection = null;
@@ -7116,7 +7116,7 @@ async function ensureDesktopDashboardUrl({ timeoutMs = 2_500 } = {}) {
   return Promise.race([desktopDashboardDiscoveryPromise, timer]);
 }
 
-async function ensureProfileWsConnection({ readyTimeoutMs = 8_000 } = {}) {
+async function ensureProfileWsConnection({ readyTimeoutMs = 8_000, allowDashboardTrust = false } = {}) {
   if (isRemoteWsMode()) return ensureRemoteWsClient();
   // The dashboard WS (/api/ws) lives on the DESKTOP dashboard's random port —
   // the 8642 sidecar has no such route and a connect attempt there hangs
@@ -7131,45 +7131,49 @@ async function ensureProfileWsConnection({ readyTimeoutMs = 8_000 } = {}) {
   if (profileWsConnection?.client?.readyState === 1 && profileWsConnection.key === key) {
     return profileWsConnection;
   }
-  // Train 2: profiles.list rides an authenticated gateway WS. Prefer the ticketed
-  // client the ordinary chat already established (single-use ?ticket= is the only
-  // WS credential when the dashboard auth gate is engaged — the legacy ?token=
-  // query path is rejected there). Local loopback without a trusted dashboard tab
-  // falls back to the legacy ?token= path, which loopback accepts.
-  const canMintDashboardTicket = transportUsesDashboardTicket(settings.connectionTransport)
-    && Number.isFinite(trustedDashboardTabId)
+  // Auth-gated local dashboards use the same explicitly trusted, signed-in
+  // Dashboard tab and one-use ticket as Remote Dashboard Attach. The local API
+  // key authenticates port 8642; it cannot authenticate the dashboard on 9119.
+  let trustedTab = null;
+  if (Number.isFinite(trustedDashboardTabId) && dashboardTicketOriginMatches(baseUrl)) {
+    trustedTab = await findDashboardTab(browserApi.tabs, originOf(baseUrl), trustedDashboardTabId);
+    if (!trustedTab) trustedDashboardTabId = null;
+  }
+  if (allowDashboardTrust && !trustedTab) {
+    await requestDashboardOriginTrust(baseUrl, { local: true });
+    trustedTab = await findDashboardTab(browserApi.tabs, originOf(baseUrl), trustedDashboardTabId);
+  }
+  const canMintDashboardTicket = Boolean(trustedTab?.id)
     && dashboardTicketOriginMatches(baseUrl);
   if (canMintDashboardTicket) {
-    let ticket = null;
-    try {
-      ticket = await Promise.race([
-        mintWsTicket({
-          tabsApi: browserApi.tabs,
-          scriptingApi: browserApi.scripting,
-          baseUrl,
-          tabId: trustedDashboardTabId,
-        }),
-        new Promise((resolve) => setTimeout(() => resolve({ ok: false, reason: 'ticket-timeout' }), 5_000)),
-      ]);
-    } catch {
-      ticket = null;
+    const ticket = await Promise.race([
+      mintWsTicket({
+        tabsApi: browserApi.tabs,
+        scriptingApi: browserApi.scripting,
+        baseUrl,
+        tabId: trustedTab.id,
+      }),
+      new Promise((resolve) => setTimeout(() => resolve({ ok: false, reason: 'ticket-timeout' }), 5_000)),
+    ]);
+    if (!ticket?.ok) {
+      const error = new Error(ticketFailureHelp(ticket?.reason, ticket?.origin || baseUrl));
+      error.ticketReason = ticket?.reason || 'ticket-failed';
+      throw error;
     }
-    if (ticket?.ok) {
-      profileWsConnection?.client?.close?.();
-      const gatewayClient = createGatewayClient({ WebSocketImpl: WebSocket, requestTimeoutMs: 60_000, readyTimeoutMs });
-      gatewayClient.on('close', () => {
-        if (profileWsConnection?.client === gatewayClient) profileWsConnection = null;
-      });
-      gatewayClient.on('sessions.changed', () => {
-        if (activeGroupProjection) void syncActiveGroupRoomFromGateway();
-      });
-      gatewayClient.on('profiles.changed', () => {
-        void loadProfiles({ quiet: true });
-      });
-      await gatewayClient.connect(buildDashboardWsUrl(baseUrl, ticket.ticket));
-      profileWsConnection = { client: gatewayClient, baseUrl, key };
-      return profileWsConnection;
-    }
+    profileWsConnection?.client?.close?.();
+    const gatewayClient = createGatewayClient({ WebSocketImpl: WebSocket, requestTimeoutMs: 60_000, readyTimeoutMs });
+    gatewayClient.on('close', () => {
+      if (profileWsConnection?.client === gatewayClient) profileWsConnection = null;
+    });
+    gatewayClient.on('sessions.changed', () => {
+      if (activeGroupProjection) void syncActiveGroupRoomFromGateway();
+    });
+    gatewayClient.on('profiles.changed', () => {
+      void loadProfiles({ quiet: true });
+    });
+    await gatewayClient.connect(buildDashboardWsUrl(baseUrl, ticket.ticket));
+    profileWsConnection = { client: gatewayClient, baseUrl, key };
+    return profileWsConnection;
   }
   if (profileWsConnection?.client?.readyState === 1 && profileWsConnection.key === key) {
     return profileWsConnection;
@@ -8337,7 +8341,7 @@ const CANONICAL_FALLBACK_GROUP_CHATS = [];
 
 let desktopDashboardUrl = '';
 
-async function loadProfiles({ quiet = false } = {}) {
+async function loadProfiles({ quiet = false, allowDashboardTrust = !quiet } = {}) {
   // Profiles load regardless of Bot Mode: the Settings → Active profile
   // selector and regular (non-Bot) sessions need the verified roster too.
   // Bot Mode only adds the deck/roster UI on top; the underlying profile
@@ -8364,19 +8368,33 @@ async function loadProfiles({ quiet = false } = {}) {
     if (!quiet) setStatus('ok', 'Hermes profiles synced', `${availableProfiles.length} profile${availableProfiles.length === 1 ? '' : 's'} available`);
   };
   let rosterLoaded = false;
-  const richRosterPromise = profileRichRosterPromise || (profileRichRosterPromise = (async () => {
-    try {
-      const connection = await ensureProfileWsConnection({ readyTimeoutMs: 5_000 });
-      return {
-        payload: await connection.client.request(WS_METHODS.profilesList, { include_sessions: true }),
-        sourceId: connection.baseUrl || normalizeGatewayUrl(settings.gatewayUrl),
-      };
-    } catch (error) {
-      return { error };
-    }
-  })().finally(() => {
-    profileRichRosterPromise = null;
-  }));
+  const createRichRosterPromise = () => {
+    let pending;
+    pending = (async () => {
+      try {
+        const connection = await ensureProfileWsConnection({ readyTimeoutMs: 5_000, allowDashboardTrust });
+        return {
+          payload: await connection.client.request(WS_METHODS.profilesList, { include_sessions: true }),
+          sourceId: connection.baseUrl || normalizeGatewayUrl(settings.gatewayUrl),
+        };
+      } catch (error) {
+        return { error };
+      }
+    })().finally(() => {
+      if (profileRichRosterPromise === pending) {
+        profileRichRosterPromise = null;
+        profileRichRosterAllowsTrust = false;
+      }
+    });
+    profileRichRosterPromise = pending;
+    profileRichRosterAllowsTrust = allowDashboardTrust;
+    return pending;
+  };
+  const mayReuseRichRoster = profileRichRosterPromise
+    && !(allowDashboardTrust && !profileRichRosterAllowsTrust);
+  const richRosterPromise = mayReuseRichRoster
+    ? profileRichRosterPromise
+    : createRichRosterPromise();
   const applyRichRoster = (result) => {
     if (generation !== botModeRosterGeneration || !result?.payload) return false;
     const split = splitBotRosterRows(result.payload, { sourceId: result.sourceId });
@@ -8416,9 +8434,11 @@ async function loadProfiles({ quiet = false } = {}) {
           // titles, previews, and group chats; its failure is non-fatal.
         }
       }
-    } catch {
+    } catch (error) {
       if (generation !== botModeRosterGeneration) return;
-      botModeRosterNote = 'Desktop dashboard roster unavailable; trying the gateway WebSocket.';
+      botModeRosterNote = error?.message === 'dashboard-authentication-required'
+        ? 'Dashboard authentication required. Open the signed-in local Dashboard tab, then refresh profiles to authorize Bot Mode.'
+        : 'Desktop dashboard roster unavailable; trying the gateway WebSocket.';
     }
   }
   if (rosterLoaded) return;
@@ -8436,6 +8456,9 @@ async function loadProfiles({ quiet = false } = {}) {
   }
   if (richResult?.timedOut) {
     botModeRosterNote = 'Hermes is still syncing the rich Bot Mode roster in the background.';
+  }
+  if (richResult?.error && allowDashboardTrust) {
+    botModeRosterNote = String(richResult.error?.message || botModeRosterNote);
   }
 
   // Do NOT inject synthetic/hardcoded agent profiles.
@@ -12246,9 +12269,11 @@ async function saveSettingsFromForm() {
     connectionTransport,
     gatewayMode,
     gatewayUrl,
-    trustedDashboardOrigin: isTrustedDashboardOrigin(gatewayUrl, settings.trustedDashboardOrigin)
+    trustedDashboardOrigin: connectionMode === 'local'
       ? settings.trustedDashboardOrigin
-      : '',
+      : (isTrustedDashboardOrigin(gatewayUrl, settings.trustedDashboardOrigin)
+        ? settings.trustedDashboardOrigin
+        : ''),
     apiKey: connectionMode === 'cloud' ? '' : apiKey,
     tokenSource: connectionMode === 'cloud' ? '' : tokenSource,
     model: settings.model || DEFAULT_SETTINGS.model,
@@ -12315,7 +12340,7 @@ async function saveSettingsFromForm() {
     botModeRoster = [];
     renderBotModeRoster();
   }
-  if (gatewayMode !== 'remote-dashboard' || !settings.trustedDashboardOrigin) {
+  if (!settings.trustedDashboardOrigin) {
     trustedDashboardTabId = null;
   }
   const stored = await browserApi.storage.local.get('hermesBrowserSettings');
@@ -13220,9 +13245,9 @@ function applyTurnRuntimePayload(payload = {}) {
   applyPendingModelRuntimeAck(runtime);
 }
 
-async function requestDashboardOriginTrust(baseUrl) {
+async function requestDashboardOriginTrust(baseUrl, { local = false } = {}) {
   const origin = originOf(baseUrl);
-  if (!origin) throw new Error('Set a remote https gateway URL without embedded credentials before connecting.');
+  if (!origin) throw new Error('Set or discover a valid HTTPS or loopback Dashboard URL before connecting.');
   const tab = await findDashboardTab(browserApi.tabs, origin);
   if (!tab?.id) {
     const error = new Error(ticketFailureHelp('no_dashboard_tab', origin));
@@ -13237,7 +13262,10 @@ async function requestDashboardOriginTrust(baseUrl) {
   }
   const approved = globalThis.confirm?.(dashboardTrustPrompt(origin)) === true;
   if (!approved) {
-    const error = new Error('Dashboard Attach was not approved. Open Settings → Test connection when you are ready to trust this origin.');
+    const retry = local
+      ? 'Keep the signed-in local Dashboard tab active, then reopen Bot Mode or refresh profiles when you are ready.'
+      : 'Open Settings → Test connection when you are ready to trust this origin.';
+    const error = new Error(`Dashboard Attach was not approved. ${retry}`);
     error.ticketReason = 'dashboard_origin_untrusted';
     throw error;
   }
@@ -15152,7 +15180,7 @@ function bindEvents() {
     els.botModePanel.hidden = !opening;
     els.botModeButton.setAttribute('aria-expanded', String(opening));
     if (opening) {
-      if (!botModeRoster.length) void loadProfiles({ quiet: true });
+      if (!botModeRoster.length) void loadProfiles({ quiet: true, allowDashboardTrust: true });
       setBotModeView(botModeView);
       els.botModeSearch?.focus();
     }

--- a/tests/bot-mode-wiring.test.mjs
+++ b/tests/bot-mode-wiring.test.mjs
@@ -26,7 +26,7 @@ test('Profiles always load; cron and PetDex stay Bot-Mode-gated', () => {
   // Profiles are a shared Hermes runtime surface: the Settings Active-profile
   // selector and regular (non-Bot) sessions need the verified roster even
   // with Bot Mode off. Only the Bot Mode deck UI is gated behind the toggle.
-  assert.match(sidepanelSource, /async function loadProfiles\(\{ quiet = false \} = \{\}\) \{\s*\/\/ Profiles load regardless of Bot Mode/);
+  assert.match(sidepanelSource, /async function loadProfiles\(\{ quiet = false, allowDashboardTrust = !quiet \} = \{\}\) \{\s*\/\/ Profiles load regardless of Bot Mode/);
   assert.match(sidepanelSource, /async function loadCronJobs\(\{ quiet = false \} = \{\}\) \{\s*if \(settings\.botModeEnabled !== true\) return/);
   assert.match(sidepanelSource, /async function ensurePetGallery\(\) \{\s*if \(settings\.botModeEnabled !== true\) return/);
 });
@@ -156,14 +156,20 @@ test('named-profile drafts and reopened sessions stay on the profile-aware dashb
   assert.match(openBody, /isNamedHermesProfile\(session\.profile/);
 });
 
-test('local dashboard fallback and first-paint loading never depend on a stale API key', () => {
+test('authenticated local dashboards reuse the explicit Dashboard ticket transport', () => {
   assert.match(sidepanelSource, /if \(state\.state === 'unconfigured' && !usesDashboardWsChatTransport\(\)\)/);
   assert.match(sidepanelSource, /activateLocalDashboardTransport\(\{ timeoutMs: 5_000 \}\)/);
   assert.match(sidepanelSource, /loadModels\(\{ quiet: true, startup: true \}\)/);
   assert.match(sidepanelSource, /dashboard-roster-timeout/);
-  assert.match(sidepanelSource, /ensureProfileWsConnection\(\{ readyTimeoutMs: 5_000 \}\)/);
-  assert.match(sidepanelSource, /transportUsesDashboardTicket\(settings\.connectionTransport\)/);
-  assert.match(sidepanelSource, /!botModeRoster\.length\) void loadProfiles\(\{ quiet: true \}\)/);
+  const connectionBody = sidepanelSource.match(/async function ensureProfileWsConnection\([\s\S]*?(?=\nfunction usesDashboardWsChatTransport)/)?.[0] || '';
+  assert.match(connectionBody, /requestDashboardOriginTrust\(baseUrl, \{ local: true \}\)/);
+  assert.match(connectionBody, /mintWsTicket\(/);
+  assert.doesNotMatch(connectionBody, /transportUsesDashboardTicket/);
+  assert.match(sidepanelSource, /!botModeRoster\.length\) void loadProfiles\(\{ quiet: true, allowDashboardTrust: true \}\)/);
+  assert.match(connectionBody, /findDashboardTab\(browserApi\.tabs, originOf\(baseUrl\), trustedDashboardTabId\)/);
+  assert.match(sidepanelSource, /profileRichRosterAllowsTrust/);
+  assert.match(sidepanelSource, /allowDashboardTrust && !profileRichRosterAllowsTrust/);
+  assert.match(sidepanelSource, /reopen Bot Mode or refresh profiles/);
 });
 
 test('profile switching and bot opening use cached row metadata before slow model options', () => {

--- a/tests/dashboard-bridge.test.mjs
+++ b/tests/dashboard-bridge.test.mjs
@@ -27,6 +27,13 @@ test('originOf and wsTicketUrl normalize the dashboard base', () => {
   assert.equal(wsTicketUrl('https://host.ts.net/hermes?x=1#y'), 'https://host.ts.net/hermes/api/auth/ws-ticket');
 });
 
+test('dashboard trust accepts loopback HTTP without allowing remote plaintext origins', () => {
+  assert.equal(originOf('http://127.0.0.1:9119/dashboard'), 'http://127.0.0.1:9119');
+  assert.equal(originOf('http://localhost:9119/dashboard'), 'http://localhost:9119');
+  assert.equal(originOf('http://host.ts.net'), '');
+  assert.equal(isTrustedDashboardOrigin('http://127.0.0.1:9119', 'http://127.0.0.1:9119/'), true);
+});
+
 test('dashboard trust is bound to one canonical HTTPS origin', () => {
   assert.equal(isTrustedDashboardOrigin('https://host.ts.net/hermes', 'https://host.ts.net'), true);
   assert.equal(isTrustedDashboardOrigin('https://host.ts.net/other', 'https://host.ts.net/'), true);
@@ -248,6 +255,28 @@ test('mintWsTicket injects the mint into the dashboard tab with the ticket URL',
   assert.deepEqual(result, { ok: true, ticket: 'TKT', ttlSeconds: 30 });
   assert.equal(injected.target.tabId, 7);
   assert.deepEqual(injected.args, ['https://host.ts.net/api/auth/ws-ticket']);
+});
+
+test('mintWsTicket reuses the signed-in local Dashboard tab', async () => {
+  const dashboardTab = {
+    id: 11,
+    url: 'http://127.0.0.1:9119/',
+    status: 'complete',
+    discarded: false,
+  };
+  const result = await mintWsTicket({
+    tabsApi: {
+      query: async () => [dashboardTab],
+      get: async () => ({ ...dashboardTab }),
+    },
+    scriptingApi: {
+      executeScript: async () => [{ result: { ok: true, ticket: 'LOCAL', ttlSeconds: 30 } }],
+    },
+    baseUrl: 'http://127.0.0.1:9119',
+    mintFn: () => {},
+  });
+
+  assert.deepEqual(result, { ok: true, ticket: 'LOCAL', ttlSeconds: 30 });
 });
 
 test('mintWsTicket discards a ticket when the selected dashboard tab navigates', async () => {

--- a/tests/desktop-roster.test.mjs
+++ b/tests/desktop-roster.test.mjs
@@ -52,6 +52,27 @@ test('dynamic dashboard discovery uses the sidecar candidate route before scanni
   ]);
 });
 
+test('dynamic dashboard discovery recognizes an authenticated dashboard through public status', async () => {
+  const fetchFn = async (url) => {
+    const target = String(url);
+    if (target === 'http://127.0.0.1:9119') {
+      return response({ body: '<title>Sign in — Hermes Agent</title>' });
+    }
+    if (target === 'http://127.0.0.1:9119/api/status') {
+      return response({ json: { auth_required: true, profiles: ['default', 'agency', 'learning'] } });
+    }
+    return response({ status: 404, body: 'not found' });
+  };
+
+  const discovered = await discoverLocalDashboardBaseUrl({
+    gatewayUrl: 'http://127.0.0.1:8642',
+    fetchFn,
+    timeoutMs: 2_000,
+  });
+
+  assert.equal(discovered, 'http://127.0.0.1:9119');
+});
+
 test('dashboard roster fetch bootstraps a token and sends it only to the dashboard API', async () => {
   const calls = [];
   const fetchFn = async (url, options = {}) => {
@@ -72,4 +93,28 @@ test('dashboard roster fetch bootstraps a token and sends it only to the dashboa
   assert.equal(calls[0].headers['X-Hermes-Session-Token'], undefined);
   assert.equal(calls[1].url, 'http://127.0.0.1:43210/api/profiles?include_sessions=true');
   assert.equal(calls[1].headers['X-Hermes-Session-Token'], 'dash-token');
+});
+
+test('dashboard roster falls back to public status when authentication hides the session token', async () => {
+  const calls = [];
+  const fetchFn = async (url) => {
+    calls.push(String(url));
+    if (String(url) === 'http://127.0.0.1:9119') {
+      return response({ body: '<title>Sign in — Hermes Agent</title>' });
+    }
+    return response({ json: { auth_required: true, profiles: ['default', 'agency', 'learning'] } });
+  };
+
+  const payload = await fetchRosterFromDashboard({
+    baseUrl: 'http://127.0.0.1:9119',
+    fetchFn,
+  });
+
+  assert.deepEqual(payload, {
+    profiles: [{ name: 'default' }, { name: 'agency' }, { name: 'learning' }],
+  });
+  assert.deepEqual(calls, [
+    'http://127.0.0.1:9119',
+    'http://127.0.0.1:9119/api/status',
+  ]);
 });

--- a/tests/desktop-roster.test.mjs
+++ b/tests/desktop-roster.test.mjs
@@ -59,7 +59,7 @@ test('dynamic dashboard discovery recognizes an authenticated dashboard through 
       return response({ body: '<title>Sign in — Hermes Agent</title>' });
     }
     if (target === 'http://127.0.0.1:9119/api/status') {
-      return response({ json: { auth_required: true, profiles: ['default', 'agency', 'learning'] } });
+      return response({ json: { version: '0.21.0', auth_required: true, gateway_mode: 'multiple', profiles: ['default', 'agency', 'learning'] } });
     }
     return response({ status: 404, body: 'not found' });
   };
@@ -71,6 +71,27 @@ test('dynamic dashboard discovery recognizes an authenticated dashboard through 
   });
 
   assert.equal(discovered, 'http://127.0.0.1:9119');
+});
+
+test('dynamic dashboard discovery rejects generic profile-shaped status payloads', async () => {
+  const fetchFn = async (url) => {
+    const target = String(url);
+    if (target === 'http://127.0.0.1:43210') {
+      return response({ body: '<title>Sign in</title>' });
+    }
+    if (target === 'http://127.0.0.1:43210/api/status') {
+      return response({ json: { auth_required: false, profiles: [] } });
+    }
+    return response({ status: 404, body: 'not found' });
+  };
+
+  const discovered = await discoverLocalDashboardBaseUrl({
+    explicitUrl: 'http://127.0.0.1:43210',
+    fetchFn,
+    timeoutMs: 500,
+  });
+
+  assert.equal(discovered, '');
 });
 
 test('dashboard roster fetch bootstraps a token and sends it only to the dashboard API', async () => {
@@ -95,24 +116,28 @@ test('dashboard roster fetch bootstraps a token and sends it only to the dashboa
   assert.equal(calls[1].headers['X-Hermes-Session-Token'], 'dash-token');
 });
 
-test('dashboard roster falls back to public status when authentication hides the session token', async () => {
+test('dashboard roster requires signed-in Dashboard authentication instead of trusting public status', async () => {
   const calls = [];
   const fetchFn = async (url) => {
     calls.push(String(url));
     if (String(url) === 'http://127.0.0.1:9119') {
       return response({ body: '<title>Sign in — Hermes Agent</title>' });
     }
-    return response({ json: { auth_required: true, profiles: ['default', 'agency', 'learning'] } });
+    return response({
+      json: {
+        version: '0.21.0',
+        auth_required: true,
+        gateway_mode: 'multiple',
+        profiles: ['default', 'agency', 'learning'],
+      },
+    });
   };
 
-  const payload = await fetchRosterFromDashboard({
+  await assert.rejects(fetchRosterFromDashboard({
     baseUrl: 'http://127.0.0.1:9119',
     fetchFn,
-  });
+  }), /dashboard-authentication-required/);
 
-  assert.deepEqual(payload, {
-    profiles: [{ name: 'default' }, { name: 'agency' }, { name: 'learning' }],
-  });
   assert.deepEqual(calls, [
     'http://127.0.0.1:9119',
     'http://127.0.0.1:9119/api/status',


### PR DESCRIPTION
## What does this PR do?

Fixes Local gateway Bot Mode roster discovery when the local Hermes Dashboard requires authentication. Auth-gated dashboards return sign-in HTML from `/`, so the legacy token bootstrap cannot authenticate `/api/profiles` or the Dashboard WebSocket.

The extension now reuses the existing Trusted Dashboard Attach flow instead of treating public status names as verified agents:

1. Strict, deadline-bounded `/api/status` probing identifies the authenticated local Dashboard.
2. On an explicit Bot Mode open or profile refresh, the extension asks the user to trust the active signed-in local Dashboard tab.
3. The existing `mintWsTicket()` bridge mints a short-lived, one-use ticket inside that first-party tab.
4. `profiles.list` and subsequent Bot sessions use the authenticated Dashboard WebSocket.

Plaintext Dashboard Attach remains restricted to exact loopback hosts (`127.0.0.1`, `localhost`, and `[::1]`); non-loopback Dashboard origins still require HTTPS. Stale trusted tab IDs are rebound safely, and explicit trust requests cannot be swallowed by an in-flight background roster probe.

## Related Issue / Phase

Fixes #99

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change adding new browser capability)
- [ ] Browser compatibility (Edge, Brave, Comet, Opera, Firefox, etc.)
- [x] Security & Privacy hardening (consent gates, redaction, sandbox isolation)
- [ ] UI & Design polish (theme studio, side panel, animations, Nous theme)
- [x] Documentation update (README, developer guides)
- [x] Tests (unit tests, Chrome-for-Testing / E2E suites)
- [ ] Refactor (internal cleanup with zero behavior change)

## Changes Made

- Extended the existing Dashboard origin/ticket broker to accept credential-free loopback HTTP while rejecting remote plaintext and embedded credentials.
- Changed public `/api/status` from roster authority to strict authenticated-Dashboard identification only.
- Reused explicit Dashboard origin/tab trust and `mintWsTicket()` for authenticated local `profiles.list` and Bot session traffic.
- Revalidated stale remembered tab IDs and rebound to the active same-origin Dashboard tab.
- Prevented explicit trust-capable loads from reusing background no-trust roster probes.
- Added actionable local authorization and retry guidance.
- Added regression coverage for loopback trust, local ticket minting, strict status identification, authenticated roster enforcement, and side-panel wiring.

## How to Test

1. `node --test tests/dashboard-bridge.test.mjs tests/desktop-roster.test.mjs tests/bot-mode.test.mjs tests/bot-mode-wiring.test.mjs tests/common.test.mjs`
2. `npm run verify`
3. Run the API server on `127.0.0.1:8642` and an authentication-gated Dashboard on `127.0.0.1:9119`.
4. Sign in to the Dashboard and leave that tab active.
5. Open Bot Mode or refresh profiles, approve the exact local Dashboard origin, and confirm the named profiles load and open through the Dashboard WebSocket.

## Checklist

### Code & Manifest

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits or workspace artifacts)
- [x] All tests pass: `npm test` and `npm run verify`
- [x] JavaScript syntax check passes: `npm run check:js`
- [x] Manifest and locales are valid: `npm run check:manifest`
- [x] Zero eval / zero remote script execution (strict MV3 compliance)

### Cross-Browser & Safety

- [ ] Tested on target browser(s)
- [x] Context consent rules preserved (no ambient page capture without user consent)
- [x] No hardcoded secrets, tokens, or unredacted personal credentials

## Screenshots / Logs

No visual layout changes.

- Targeted authenticated transport suite: 286 tests passed.
- Final lifecycle regression suite: 60 tests passed.
- `npm run verify`: 1390 tests passed; JavaScript, self-contained extension, i18n, locale, and manifest checks passed.
- Changed-file ESLint: 0 errors. Repository-wide `npm run lint` remains blocked by the existing `extension/lib/pet-avatar.mjs:109` undefined-symbol error outside this PR.
- Final independent review: no remaining Critical or Important findings; ready to merge.