### PR TITLE
fix(sidepanel): keep the model picker inside the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the side-panel model picker opening partly above the viewport, which hid its search box and provider selector with no way to scroll them back into view. The bottom-anchored popovers now reserve the live composer dock height instead of a fixed 176px, and the model list and runtime options shrink and scroll instead of pushing the header off-screen.
+
 ## [0.2.0] - 2026-07-21
 
 ### Added

--- a/extension/sidepanel.css
+++ b/extension/sidepanel.css
@@ -3072,12 +3072,19 @@ textarea:focus, input:focus, select:focus { border-color: var(--hermes-accent); 
 .context-popover {
   position: absolute;
   bottom: calc(var(--hermes-bottom-dock-height, 0px) + 6px);
+  /* Keep bottom-anchored popovers inside the viewport: the space above the dock
+     is what is actually available, so reserve the live dock height instead of a
+     fixed guess. Otherwise a tall composer pushes the popover's top rows (search
+     box and provider picker) above the viewport, where `overflow: hidden` makes
+     them unreachable. */
+  max-height: calc(100vh - var(--hermes-bottom-dock-height, 0px) - 18px);
   z-index: 70;
 }
+.context-popover { overflow-y: auto; }
 .model-menu {
   display: grid;
-  grid-template-rows: auto minmax(58px, auto) minmax(96px, 1fr) auto auto;
-  max-height: min(480px, calc(100vh - 176px));
+  grid-template-rows: auto minmax(58px, auto) minmax(0, 1fr) minmax(0, auto) auto;
+  max-height: min(480px, calc(100vh - var(--hermes-bottom-dock-height, 0px) - 18px));
   overflow: hidden;
 }
 .model-menu-head { display: none; }
@@ -3086,7 +3093,7 @@ textarea:focus, input:focus, select:focus { border-color: var(--hermes-accent); 
   inset: auto 12px auto 12px;
   width: auto;
   max-height: min(560px, calc(100vh - 96px));
-  grid-template-rows: auto auto minmax(58px, auto) minmax(120px, 1fr) auto auto;
+  grid-template-rows: auto auto minmax(58px, auto) minmax(0, 1fr) minmax(0, auto) auto;
   z-index: 100;
   box-shadow: 10px 10px 0 rgba(var(--hermes-shadow-rgb),0.2);
 }
@@ -3276,6 +3283,8 @@ textarea:focus, input:focus, select:focus { border-color: var(--hermes-accent); 
 .model-option-meta,
 .session-option-meta { color: rgba(var(--hermes-fg-rgb),0.58); font-size: 10px; }
 .model-options-list {
+  min-height: 0;
+  overflow-y: auto;
   border-top: 1px solid rgba(var(--hermes-fg-rgb),0.18);
   padding: 7px 10px 8px;
   background: rgba(0,0,0,0.10);


### PR DESCRIPTION
## Problem

Opening the model picker in the side panel can render it with its top rows above the top of the viewport. The **search box and the provider selector are cut off entirely** — the menu appears to open straight onto the model list, with only the provider row's horizontal scrollbar peeking in at the top edge. There is no way to recover them: `.model-menu` is `overflow: hidden`, so the clipped rows cannot be scrolled back.

That makes it impossible to switch providers or search models from the side panel; the user is stuck with whatever provider happens to be selected.

## Cause

The menu is bottom-anchored above the composer dock:

```css
.model-menu, .context-popover {
  position: absolute;
  bottom: calc(var(--hermes-bottom-dock-height, 0px) + 6px);
}
.model-menu {
  max-height: min(480px, calc(100vh - 176px));
  overflow: hidden;
}
```

The `bottom` offset tracks the live dock height (`--hermes-bottom-dock-height`, kept up to date by `updateDockFloatingAnchor()`), but `max-height` reserves a hardcoded **176px**. The real dock is routinely much taller than that once the attachment row, the `Enter sends…` help text, the composer actions and the desktop bar are laid out — around 300px in a normal side panel.

So the box is placed at `bottom + 480px`, which lands above the viewport top, and `overflow: hidden` makes the overflowing header unreachable.

Measured in a side panel at 635x760 with a 304px dock, before the change:

```
dock=304px vh=673  menu.top=-117  menu.height=480
searchTop=-116  providerListTop=-81
```

The 58px provider row sits entirely off-screen (`-81 … -23`).

A secondary contributor: the grid rows `minmax(58px, auto) minmax(96px, 1fr) auto auto` give the model list a 96px floor and the runtime-options block an unbounded `auto` row, so when space is tight those rows push the search box and provider selector out of the box instead of shrinking.

## Fix

- Cap `.model-menu` / `.context-popover` against the live dock height rather than a fixed guess:
  `max-height: min(480px, calc(100vh - var(--hermes-bottom-dock-height, 0px) - 18px))`.
  The `0px` fallback keeps the pre-measurement first paint correct.
- Let the model list and the runtime-options rows shrink and scroll (`minmax(0, 1fr)` / `minmax(0, auto)`, plus `min-height: 0; overflow-y: auto` on `.model-options-list`) instead of pushing the header off-screen. Applied to both the chat and the Hermes Assist grid templates.
- Give `.context-popover` the same max-height and `overflow-y: auto`; it shares the same bottom anchor and the same failure mode.

CSS-only, no markup or behavior change.

After, same layout:

```
dock=304px vh=673  menu.top=12  menu.height=351
searchTop=13  providerListTop=48
```

## Verification

Rendered the real `sidepanel.html` + `sidepanel.css` with a populated model menu (4 providers, 13 models, 7 effort levels) in headless Chrome.

| viewport | dock | `menu.top` before | `menu.top` after |
| --- | --- | --- | --- |
| 360x700 | 304px | off-screen | 12px |
| 400x520 | 304px | off-screen | 12px |
| 635x760 | 304px | -117px | 12px |
| 635x1400 | 304px | ok | 523px |

Search box and provider selector are fully visible in every case, for both the chat and the Hermes Assist (`data-selection-target="assist"`) targets.

- `npm run check:js` — pass
- `npm run check:manifest` — pass
- `npm run lint` — 0 errors (873 pre-existing warnings)
- `npm test` — 1197/1207 pass. The 10 failures are in `tests/companion-plugin.test.mjs` and related Python-companion suites and reproduce identically on unmodified `main` in this environment; they are unrelated to this change.